### PR TITLE
Add support for LobbyV3 and AuthV1 API services

### DIFF
--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -4,6 +4,7 @@
 #include "HathoraSDKModule.h"
 #include "HathoraSDKDiscoveryV1.h"
 #include "HathoraSDKRoomV2.h"
+#include "HathoraSDKLobbyV3.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
@@ -23,6 +24,7 @@ UHathoraSDK* UHathoraSDK::CreateHathoraSDK(FString AppId, FHathoraSDKSecurity Se
 	UHathoraSDK* SDK = NewObject<UHathoraSDK>();
 	SDK->DiscoveryV1 = NewObject<UHathoraSDKDiscoveryV1>();
 	SDK->RoomV2 = NewObject<UHathoraSDKRoomV2>();
+	SDK->LobbyV3 = NewObject<UHathoraSDKLobbyV3>();
 
 	SDK->SetCredentials(AppId, Security);
 
@@ -33,6 +35,7 @@ void UHathoraSDK::SetCredentials(FString AppId, FHathoraSDKSecurity Security)
 {
 	DiscoveryV1->SetCredentials(AppId, Security);
 	RoomV2->SetCredentials(AppId, Security);
+	LobbyV3->SetCredentials(AppId, Security);
 }
 
 void UHathoraSDK::OnGetRegionalPingsCompleteWrapper(FHathoraRegionPings Result)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -2,9 +2,10 @@
 
 #include "HathoraSDK.h"
 #include "HathoraSDKModule.h"
+#include "HathoraSDKAuthV1.h"
 #include "HathoraSDKDiscoveryV1.h"
-#include "HathoraSDKRoomV2.h"
 #include "HathoraSDKLobbyV3.h"
+#include "HathoraSDKRoomV2.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
@@ -22,9 +23,10 @@ void UHathoraSDK::GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete,
 UHathoraSDK* UHathoraSDK::CreateHathoraSDK(FString AppId, FHathoraSDKSecurity Security)
 {
 	UHathoraSDK* SDK = NewObject<UHathoraSDK>();
+	SDK->AuthV1 = NewObject<UHathoraSDKAuthV1>();
 	SDK->DiscoveryV1 = NewObject<UHathoraSDKDiscoveryV1>();
-	SDK->RoomV2 = NewObject<UHathoraSDKRoomV2>();
 	SDK->LobbyV3 = NewObject<UHathoraSDKLobbyV3>();
+	SDK->RoomV2 = NewObject<UHathoraSDKRoomV2>();
 
 	SDK->SetCredentials(AppId, Security);
 
@@ -33,9 +35,10 @@ UHathoraSDK* UHathoraSDK::CreateHathoraSDK(FString AppId, FHathoraSDKSecurity Se
 
 void UHathoraSDK::SetCredentials(FString AppId, FHathoraSDKSecurity Security)
 {
+	AuthV1->SetCredentials(AppId, Security);
 	DiscoveryV1->SetCredentials(AppId, Security);
-	RoomV2->SetCredentials(AppId, Security);
 	LobbyV3->SetCredentials(AppId, Security);
+	RoomV2->SetCredentials(AppId, Security);
 }
 
 void UHathoraSDK::OnGetRegionalPingsCompleteWrapper(FHathoraRegionPings Result)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
@@ -2,6 +2,7 @@
 
 #include "HathoraSDKAPI.h"
 #include "HathoraSDKConfig.h"
+#include "HathoraSDKModule.h"
 #include "HttpModule.h"
 #include "JsonObjectWrapper.h"
 
@@ -137,6 +138,7 @@ EHathoraCloudRegion UHathoraSDKAPI::ParseRegion(FString RegionString)
 	}
 	else
 	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("[ParseRegion] Unknown region: %s"), *RegionString);
 		return EHathoraCloudRegion::Unknown;
 	}
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
@@ -77,9 +77,9 @@ void UHathoraSDKAPI::SendRequest(
 
 	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
 
-	if (Security.HathoraDevToken.Len() > 0)
+	if (Security.AuthToken.Len() > 0)
 	{
-		Request->SetHeader(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *Security.HathoraDevToken));
+		Request->SetHeader(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *Security.AuthToken));
 	}
 
 	Request->ProcessRequest();
@@ -91,4 +91,52 @@ FString UHathoraSDKAPI::GetRegionString(EHathoraCloudRegion Region)
 	RegionString = RegionString.RightChop(RegionString.Find("::") + 2);
 
 	return RegionString;
+}
+
+EHathoraCloudRegion UHathoraSDKAPI::ParseRegion(FString RegionString)
+{
+	if (RegionString == TEXT("Seattle"))
+	{
+		return EHathoraCloudRegion::Seattle;
+	}
+	else if (RegionString == TEXT("Washington_DC"))
+	{
+		return EHathoraCloudRegion::Washington_DC;
+	}
+	else if (RegionString == TEXT("Chicago"))
+	{
+		return EHathoraCloudRegion::Chicago;
+	}
+	else if (RegionString == TEXT("London"))
+	{
+		return EHathoraCloudRegion::London;
+	}
+	else if (RegionString == TEXT("Frankfurt"))
+	{
+		return EHathoraCloudRegion::Frankfurt;
+	}
+	else if (RegionString == TEXT("Mumbai"))
+	{
+		return EHathoraCloudRegion::Mumbai;
+	}
+	else if (RegionString == TEXT("Singapore"))
+	{
+		return EHathoraCloudRegion::Singapore;
+	}
+	else if (RegionString == TEXT("Tokyo"))
+	{
+		return EHathoraCloudRegion::Tokyo;
+	}
+	else if (RegionString == TEXT("Sydney"))
+	{
+		return EHathoraCloudRegion::Sydney;
+	}
+	else if (RegionString == TEXT("Sao_Paulo"))
+	{
+		return EHathoraCloudRegion::Sao_Paulo;
+	}
+	else
+	{
+		return EHathoraCloudRegion::Unknown;
+	}
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
@@ -2,6 +2,7 @@
 
 #include "HathoraSDKAuthV1.h"
 #include "HathoraSDKModule.h"
+#include "Serialization/JsonSerializer.h"
 
 void UHathoraSDKAuthV1::LoginAnonymous(FHathoraOnLogin OnComplete)
 {

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
@@ -2,3 +2,88 @@
 
 #include "HathoraSDKAuthV1.h"
 #include "HathoraSDKModule.h"
+
+void UHathoraSDKAuthV1::LoginAnonymous(FHathoraOnLogin OnComplete)
+{
+	Login(
+		FString::Printf(TEXT("/auth/v1/%s/login/anonymous"), *AppId),
+		FJsonObject(),
+		OnComplete
+	);
+}
+
+void UHathoraSDKAuthV1::LoginNickname(FString Nickname, FHathoraOnLogin OnComplete)
+{
+	FJsonObject Body;
+	Body.SetStringField(TEXT("nickname"), Nickname);
+
+	Login(
+		FString::Printf(TEXT("/auth/v1/%s/login/nickname"), *AppId),
+		Body,
+		OnComplete
+	);
+}
+
+void UHathoraSDKAuthV1::LoginGoogle(FString IdToken, FHathoraOnLogin OnComplete)
+{
+	FJsonObject Body;
+	Body.SetStringField(TEXT("idToken"), IdToken);
+
+	Login(
+		FString::Printf(TEXT("/auth/v1/%s/login/google"), *AppId),
+		Body,
+		OnComplete
+	);
+}
+
+void UHathoraSDKAuthV1::Login(FString Path, FJsonObject Body, FHathoraOnLogin OnComplete)
+{
+	SendRequest(
+		TEXT("POST"),
+		Path,
+		Body,
+		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		{
+			FHathoraLoginResult Result;
+			if (bSuccess && Response.IsValid())
+			{
+				Result.StatusCode = Response->GetResponseCode();
+				FString Content = Response->GetContentAsString();
+
+				if (Result.StatusCode == 200)
+				{
+					TSharedPtr<FJsonObject> OutObject;
+					TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+					FJsonSerializer::Deserialize(Reader, OutObject);
+
+					if (OutObject.IsValid())
+					{
+						Result.Token = OutObject->GetStringField(TEXT("token"));
+					}
+					else
+					{
+						Result.ErrorMessage = TEXT("Could not parse response");
+					}
+				}
+				else
+				{
+					Result.ErrorMessage = Content;
+				}
+			}
+			else
+			{
+				Result.ErrorMessage = TEXT("Could not login, unknown error");
+			}
+
+			if (!Result.ErrorMessage.IsEmpty())
+			{
+				UE_LOG(LogHathoraSDK, Error, TEXT("[LoginAnonymous] Error: %s"), *Result.ErrorMessage);
+			}
+
+			if (!OnComplete.ExecuteIfBound(Result))
+			{
+				UE_LOG(LogHathoraSDK, Warning, TEXT("[LoginAnonymous] function pointer was not valid, so OnComplete will not be called"));
+			}
+		}
+	);
+}

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
@@ -1,0 +1,4 @@
+// Copyright 2023 Hathora, Inc.
+
+#include "HathoraSDKAuthV1.h"
+#include "HathoraSDKModule.h"

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKLobbyV3.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKLobbyV3.cpp
@@ -1,0 +1,288 @@
+// Copyright 2023 Hathora, Inc.
+
+#include "HathoraSDKLobbyV3.h"
+#include "HathoraSDKModule.h"
+
+FString UHathoraSDKLobbyV3::GetVisibilityString(EHathoraLobbyVisibility Visibility)
+{
+	FString VisibilityString = UEnum::GetValueAsString(Visibility);
+	VisibilityString = VisibilityString.RightChop(VisibilityString.Find("::") + 2).ToLower();
+
+	return VisibilityString;
+}
+
+EHathoraLobbyVisibility UHathoraSDKLobbyV3::ParseVisibility(const FString& VisibilityString)
+{
+	if (VisibilityString == TEXT("private"))
+	{
+		return EHathoraLobbyVisibility::Private;
+	}
+	else if (VisibilityString == TEXT("public"))
+	{
+		return EHathoraLobbyVisibility::Public;
+	}
+	else if (VisibilityString == TEXT("local"))
+	{
+		return EHathoraLobbyVisibility::Local;
+	}
+	else
+	{
+		return EHathoraLobbyVisibility::Unknown;
+	}
+}
+
+FHathoraLobbyInfo UHathoraSDKLobbyV3::ParseLobbyInfo(TSharedPtr<FJsonObject> LobbyInfoJson)
+{
+	FHathoraLobbyInfo LobbyInfo;
+
+	LobbyInfo.ShortCode = LobbyInfoJson->GetStringField(TEXT("shortCode"));
+
+	FDateTime::ParseIso8601(
+		*LobbyInfoJson->GetStringField(TEXT("createdAt")),
+		LobbyInfo.CreatedAt
+	);
+
+	LobbyInfo.CreatedBy = LobbyInfoJson->GetStringField(TEXT("createdBy"));
+
+	// roomConfig can be null; this will keep it empty if it is
+	LobbyInfoJson->TryGetStringField(TEXT("roomConfig"), LobbyInfo.RoomConfig);
+
+	LobbyInfo.Visibility = ParseVisibility(LobbyInfoJson->GetStringField(TEXT("visibility")));
+
+	LobbyInfo.Region = ParseRegion(LobbyInfoJson->GetStringField(TEXT("region")));
+
+	LobbyInfo.RoomId = LobbyInfoJson->GetStringField(TEXT("roomId"));
+	LobbyInfo.AppId = LobbyInfoJson->GetStringField(TEXT("appId"));
+
+	return LobbyInfo;
+}
+
+void UHathoraSDKLobbyV3::CreateLobby(
+	EHathoraLobbyVisibility Visibility,
+	FString RoomConfig,
+	EHathoraCloudRegion Region,
+	FString ShortCode,
+	FString RoomId,
+	FHathoraOnLobbyInfo OnComplete)
+{
+	TArray<TPair<FString, FString>> QueryOptions;
+	if (ShortCode.Len() > 0)
+	{
+		QueryOptions.Add(TPair<FString, FString>(TEXT("shortCode"), ShortCode));
+	}
+	if (RoomId.Len() > 0)
+	{
+		QueryOptions.Add(TPair<FString, FString>(TEXT("roomId"), RoomId));
+	}
+
+	FJsonObject Body;
+	Body.SetStringField(TEXT("visibility"), GetVisibilityString(Visibility));
+	if (RoomConfig.Len() > 0)
+	{
+		Body.SetStringField(TEXT("roomConfig"), RoomConfig);
+	}
+	Body.SetStringField(TEXT("region"), GetRegionString(Region));
+
+	SendRequest(
+		TEXT("POST"),
+		FString::Printf(TEXT("/lobby/v3/%s/create"), *AppId),
+		QueryOptions,
+		Body,
+		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		{
+			FHathoraLobbyInfoResult Result;
+			if (bSuccess && Response.IsValid())
+			{
+				Result.StatusCode = Response->GetResponseCode();
+				FString Content = Response->GetContentAsString();
+
+				if (Result.StatusCode == 201)
+				{
+					TSharedPtr<FJsonObject> OutObject;
+					TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+					FJsonSerializer::Deserialize(Reader, OutObject);
+
+					if (OutObject.IsValid())
+					{
+						Result.Data = ParseLobbyInfo(OutObject);
+					}
+					else
+					{
+						Result.ErrorMessage = TEXT("Could not parse response");
+					}
+				}
+				else
+				{
+					Result.ErrorMessage = Content;
+				}
+			}
+			else
+			{
+				Result.ErrorMessage = TEXT("Could not create lobby, unknown error");
+			}
+
+			if (!Result.ErrorMessage.IsEmpty())
+			{
+				UE_LOG(LogHathoraSDK, Error, TEXT("[CreateLobby] Error: %s"), *Result.ErrorMessage);
+			}
+
+			if (!OnComplete.ExecuteIfBound(Result))
+			{
+				UE_LOG(LogHathoraSDK, Warning, TEXT("[CreateLobby] function pointer was not valid, so OnComplete will not be called"));
+			}
+		});
+}
+
+void UHathoraSDKLobbyV3::ListActivePublicLobbies(EHathoraCloudRegion Region, FHathoraOnLobbyInfos OnComplete)
+{
+	TArray<TPair<FString, FString>> QueryOptions;
+	if (Region != EHathoraCloudRegion::Unknown)
+	{
+		QueryOptions.Add(TPair<FString, FString>(TEXT("region"), GetRegionString(Region)));
+	}
+
+	SendRequest(
+		TEXT("GET"),
+		FString::Printf(TEXT("/lobby/v3/%s/list/public"), *AppId),
+		QueryOptions,
+		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		{
+			FHathoraLobbyInfosResult Result;
+			if (bSuccess && Response.IsValid())
+			{
+				Result.StatusCode = Response->GetResponseCode();
+				FString Content = Response->GetContentAsString();
+
+				if (Result.StatusCode == 200)
+				{
+					TArray<TSharedPtr<FJsonValue>> OutArray;
+					TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+					FJsonSerializer::Deserialize(Reader, OutArray);
+
+					for (TSharedPtr<FJsonValue> Value : OutArray)
+					{
+						TSharedPtr<FJsonObject> Object = Value->AsObject();
+						Result.Data.Add(ParseLobbyInfo(Object));
+					}
+				}
+				else
+				{
+					Result.ErrorMessage = Content;
+				}
+			}
+			else
+			{
+				Result.ErrorMessage = TEXT("Could not list active public lobbies, unknown error");
+			}
+
+			if (!Result.ErrorMessage.IsEmpty())
+			{
+				UE_LOG(LogHathoraSDK, Error, TEXT("[ListActivePublicLobbies] Error: %s"), *Result.ErrorMessage);
+			}
+
+			if (!OnComplete.ExecuteIfBound(Result))
+			{
+				UE_LOG(LogHathoraSDK, Warning, TEXT("[ListActivePublicLobbies] function pointer was not valid, so OnComplete will not be called"));
+			}
+		});
+}
+
+void UHathoraSDKLobbyV3::GetLobbyInfoByRoomId(FString RoomId, FHathoraOnLobbyInfo OnComplete)
+{
+	SendRequest(
+		TEXT("GET"),
+		FString::Printf(TEXT("/lobby/v3/%s/info/roomid/%s"), *AppId, *RoomId),
+		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		{
+			FHathoraLobbyInfoResult Result;
+			if (bSuccess && Response.IsValid())
+			{
+				Result.StatusCode = Response->GetResponseCode();
+				FString Content = Response->GetContentAsString();
+
+				if (Result.StatusCode == 200)
+				{
+					TSharedPtr<FJsonObject> OutObject;
+					TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+					FJsonSerializer::Deserialize(Reader, OutObject);
+
+					if (OutObject.IsValid())
+					{
+						Result.Data = ParseLobbyInfo(OutObject);
+					}
+					else
+					{
+						Result.ErrorMessage = TEXT("Could not parse response");
+					}
+				}
+				else
+				{
+					Result.ErrorMessage = Content;
+				}
+			}
+			else
+			{
+				Result.ErrorMessage = TEXT("Could not get lobby info, unknown error");
+			}
+
+			if (!Result.ErrorMessage.IsEmpty())
+			{
+				UE_LOG(LogHathoraSDK, Error, TEXT("[GetLobbyInfoByRoomId] Error: %s"), *Result.ErrorMessage);
+			}
+
+			if (!OnComplete.ExecuteIfBound(Result))
+			{
+				UE_LOG(LogHathoraSDK, Warning, TEXT("[GetLobbyInfoByRoomId] function pointer was not valid, so OnComplete will not be called"));
+			}
+		});
+}
+
+void UHathoraSDKLobbyV3::GetLobbyInfoByShortCode(FString ShortCode, FHathoraOnLobbyInfo OnComplete)
+{
+	SendRequest(
+		TEXT("GET"),
+		FString::Printf(TEXT("/lobby/v3/%s/info/shortcode/%s"), *AppId, *ShortCode),
+		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		{
+			FHathoraLobbyInfoResult Result;
+			if (bSuccess && Response.IsValid())
+			{
+				Result.StatusCode = Response->GetResponseCode();
+				FString Content = Response->GetContentAsString();
+
+				if (Result.StatusCode == 200)
+				{
+					TSharedPtr<FJsonObject> OutObject;
+					TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+					FJsonSerializer::Deserialize(Reader, OutObject);
+
+					if (OutObject.IsValid())
+					{
+						Result.Data = ParseLobbyInfo(OutObject);
+					}
+					else
+					{
+						Result.ErrorMessage = TEXT("Could not parse response");
+					}
+				}
+				else
+				{
+					Result.ErrorMessage = Content;
+				}
+			}
+			else
+			{
+				Result.ErrorMessage = TEXT("Could not get lobby info, unknown error");
+			}
+
+			if (!Result.ErrorMessage.IsEmpty())
+			{
+				UE_LOG(LogHathoraSDK, Error, TEXT("[GetLobbyInfoByShortCode] Error: %s"), *Result.ErrorMessage);
+			}
+
+			if (!OnComplete.ExecuteIfBound(Result))
+			{
+				UE_LOG(LogHathoraSDK, Warning, TEXT("[GetLobbyInfoByShortCode] function pointer was not valid, so OnComplete will not be called"));
+			}
+		});
+}

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
@@ -8,9 +8,10 @@
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "HathoraSDK.generated.h"
 
+class UHathoraSDKAuthV1;
 class UHathoraSDKDiscoveryV1;
-class UHathoraSDKRoomV2;
 class UHathoraSDKLobbyV3;
+class UHathoraSDKRoomV2;
 
 UCLASS(BlueprintType)
 class HATHORASDK_API UHathoraSDK : public UBlueprintFunctionLibrary
@@ -39,13 +40,16 @@ public:
 	void SetCredentials(FString AppId, FHathoraSDKSecurity Security);
 
 	UPROPERTY(BlueprintReadOnly, Category="HathoraSDK")
+	UHathoraSDKAuthV1* AuthV1;
+
+	UPROPERTY(BlueprintReadOnly, Category="HathoraSDK")
 	UHathoraSDKDiscoveryV1* DiscoveryV1;
 
 	UPROPERTY(BlueprintReadOnly, Category="HathoraSDK")
-	UHathoraSDKRoomV2* RoomV2;
-
-	UPROPERTY(BlueprintReadOnly)
 	UHathoraSDKLobbyV3* LobbyV3;
+
+	UPROPERTY(BlueprintReadOnly, Category="HathoraSDK")
+	UHathoraSDKRoomV2* RoomV2;
 
 private:
 	FHathoraOnGetRegionalPings OnGetRegionalPingsComplete;

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
@@ -10,6 +10,7 @@
 
 class UHathoraSDKDiscoveryV1;
 class UHathoraSDKRoomV2;
+class UHathoraSDKLobbyV3;
 
 UCLASS(BlueprintType)
 class HATHORASDK_API UHathoraSDK : public UBlueprintFunctionLibrary
@@ -42,6 +43,9 @@ public:
 
 	UPROPERTY(BlueprintReadOnly, Category="HathoraSDK")
 	UHathoraSDKRoomV2* RoomV2;
+
+	UPROPERTY(BlueprintReadOnly)
+	UHathoraSDKLobbyV3* LobbyV3;
 
 private:
 	FHathoraOnGetRegionalPings OnGetRegionalPingsComplete;

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKAPI.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKAPI.h
@@ -49,6 +49,7 @@ protected:
 	);
 
 	static FString GetRegionString(EHathoraCloudRegion Region);
+	static EHathoraCloudRegion ParseRegion(FString RegionString);
 
 	FString AppId;
 	FHathoraSDKSecurity Security;

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKAuthV1.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKAuthV1.h
@@ -7,10 +7,47 @@
 #include "HathoraTypes.h"
 #include "HathoraSDKAuthV1.generated.h"
 
+USTRUCT(BlueprintType)
+struct FHathoraLoginResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	int32 StatusCode = 0;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString ErrorMessage;
+
+	// A unique Hathora-signed JWT player token.
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString Token;
+};
+
 UCLASS(BlueprintType)
 class HATHORASDK_API UHathoraSDKAuthV1 : public UHathoraSDKAPI
 {
 	GENERATED_BODY()
 
 public:
+	UDELEGATE()
+	DECLARE_DYNAMIC_DELEGATE_OneParam(FHathoraOnLogin, FHathoraLoginResult, Result);
+
+	// Returns a unique player token for an anonymous user.
+	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | AuthV1")
+	void LoginAnonymous(FHathoraOnLogin OnComplete);
+
+	// Returns a unique player token with a specified nickname for a user.
+	// @param Nickname An alias to represent a player.
+	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | AuthV1")
+	void LoginNickname(FString Nickname, FHathoraOnLogin OnComplete);
+
+	// Returns a unique player token using a Google-signed OIDC idToken.
+	// @param IdToken A Google-signed OIDC ID token representing a player's
+	//                authenticated identity. Learn how to get an idToken
+	//                [here](https://cloud.google.com/docs/authentication/get-id-token).
+	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | AuthV1")
+	void LoginGoogle(FString IdToken, FHathoraOnLogin OnComplete);
+
+private:
+	void Login(FString Path, FJsonObject Body, FHathoraOnLogin OnComplete);
 };

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKAuthV1.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKAuthV1.h
@@ -1,0 +1,16 @@
+// Copyright 2023 Hathora, Inc.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HathoraSDKAPI.h"
+#include "HathoraTypes.h"
+#include "HathoraSDKAuthV1.generated.h"
+
+UCLASS(BlueprintType)
+class HATHORASDK_API UHathoraSDKAuthV1 : public UHathoraSDKAPI
+{
+	GENERATED_BODY()
+
+public:
+};

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKLobbyV3.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKLobbyV3.h
@@ -156,5 +156,7 @@ private:
 	static FString GetVisibilityString(EHathoraLobbyVisibility Visibility);
 	static EHathoraLobbyVisibility ParseVisibility(const FString& VisibilityString);
 
+	void ListActivePublicLobbies(TArray<TPair<FString, FString>> QueryOptions, FHathoraOnLobbyInfos OnComplete);
+
 	static FHathoraLobbyInfo ParseLobbyInfo(TSharedPtr<FJsonObject> LobbyInfoJson);
 };

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKLobbyV3.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKLobbyV3.h
@@ -1,0 +1,157 @@
+// Copyright 2023 Hathora, Inc.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HathoraSDKAPI.h"
+#include "HathoraTypes.h"
+#include "Misc/DateTime.h"
+#include "HathoraSDKLobbyV3.generated.h"
+
+UENUM(BlueprintType)
+enum class EHathoraLobbyVisibility : uint8
+{
+	// Could not parse the API response.
+	Unknown,
+
+	// The player who created the room must share the roomId with their friends.
+	Private,
+
+	// Visible in the public lobby list, anyone can join.
+	Public,
+
+	// For testing with a server running locally.
+	Local,
+};
+
+USTRUCT(BlueprintType)
+struct FHathoraLobbyInfo
+{
+	GENERATED_BODY()
+
+	// User-defined identifier for a lobby. Defaults to the RoomId
+	// if a ShortCode was not specified in CreateLobby().
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString ShortCode;
+
+	// When the lobby was created.
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FDateTime CreatedAt;
+
+	// Email address for the user that created the lobby.
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString CreatedBy;
+
+	// Optional configuration parameters for the room.
+	// Can be any string including stringified JSON.
+	// String is empty if null or not set.
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString RoomConfig;
+
+	// Types of lobbies a player can create.
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	EHathoraLobbyVisibility Visibility;
+
+	// Which region the lobby is in.
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	EHathoraCloudRegion Region;
+
+	// Unique identifier to a game session or match.
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString RoomId;
+
+	// System generated unique identifier for an application.
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString AppId;
+};
+
+USTRUCT(BlueprintType)
+struct FHathoraLobbyInfoResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	int32 StatusCode = 0;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString ErrorMessage;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FHathoraLobbyInfo Data;
+};
+
+USTRUCT(BlueprintType)
+struct FHathoraLobbyInfosResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	int32 StatusCode = 0;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString ErrorMessage;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	TArray<FHathoraLobbyInfo> Data;
+};
+
+UCLASS(BlueprintType)
+class HATHORASDK_API UHathoraSDKLobbyV3 : public UHathoraSDKAPI
+{
+	GENERATED_BODY()
+
+public:
+	UDELEGATE()
+	DECLARE_DYNAMIC_DELEGATE_OneParam(FHathoraOnLobbyInfo, FHathoraLobbyInfoResult, Result);
+
+	// Create a new lobby for an application. A lobby object is a wrapper around a room object.
+	// With a lobby, you get additional functionality like configuring the visibility of the room,
+	// managing the state of a match, and retrieving a list of public lobbies to display to players.
+	// @param Visibility Types of lobbies a player can create.
+	// @param RoomConfig Optional configuration parameters for the room. Can be
+	//                    any string including stringified JSON. It is accessible
+	//                    from the room via GetRoomInfo().
+	// @param Region The region to create the room in.
+	// @param ShortCode Optional user-defined identifier for a lobby. Leave empty
+	//                  to reference the lobby using the RoomId only.
+	// @param RoomId Unique identifier to a game session or match. Leave empty to
+	//               use the default system generated ID.
+	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | LobbyV3")
+	void CreateLobby(
+		EHathoraLobbyVisibility Visibility,
+		FString RoomConfig,
+		EHathoraCloudRegion Region,
+		FString ShortCode,
+		FString RoomId,
+		FHathoraOnLobbyInfo OnComplete
+	);
+
+	UDELEGATE()
+	DECLARE_DYNAMIC_DELEGATE_OneParam(FHathoraOnLobbyInfos, FHathoraLobbyInfosResult, Result);
+
+	// Get all active lobbies for a given application. Filter the array by optionally passing
+	// in a `Region`. Use this endpoint to display all public lobbies that a player can join
+	// in the game client.
+	// @param Region Filter the returned lobbies by the provided region. Use
+	//               EHathoraCloudRegion::Unknown to return active public lobbies
+	//               in all regions.
+	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | LobbyV3")
+	void ListActivePublicLobbies(EHathoraCloudRegion Region, FHathoraOnLobbyInfos OnComplete);
+
+	// Get details for a lobby.
+	// @param RoomId Unique identifier to a game session or match.
+	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | LobbyV3")
+	void GetLobbyInfoByRoomId(FString RoomId, FHathoraOnLobbyInfo OnComplete);
+
+	// Get details for a lobby. If 2 or more lobbies have the same shortCode, then the most
+	// recently created lobby will be returned.
+	// @param ShortCode User-defined identifier for a lobby.
+	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | LobbyV3")
+	void GetLobbyInfoByShortCode(FString ShortCode, FHathoraOnLobbyInfo OnComplete);
+
+private:
+	static FString GetVisibilityString(EHathoraLobbyVisibility Visibility);
+	static EHathoraLobbyVisibility ParseVisibility(const FString& VisibilityString);
+
+	static FHathoraLobbyInfo ParseLobbyInfo(TSharedPtr<FJsonObject> LobbyInfoJson);
+};

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKLobbyV3.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKLobbyV3.h
@@ -11,9 +11,6 @@
 UENUM(BlueprintType)
 enum class EHathoraLobbyVisibility : uint8
 {
-	// Could not parse the API response.
-	Unknown,
-
 	// The player who created the room must share the roomId with their friends.
 	Private,
 
@@ -22,6 +19,8 @@ enum class EHathoraLobbyVisibility : uint8
 
 	// For testing with a server running locally.
 	Local,
+
+	Unknown UMETA(Hidden)
 };
 
 USTRUCT(BlueprintType)
@@ -50,11 +49,11 @@ struct FHathoraLobbyInfo
 
 	// Types of lobbies a player can create.
 	UPROPERTY(BlueprintReadOnly, Category = "Default")
-	EHathoraLobbyVisibility Visibility;
+	EHathoraLobbyVisibility Visibility = EHathoraLobbyVisibility::Unknown;
 
 	// Which region the lobby is in.
 	UPROPERTY(BlueprintReadOnly, Category = "Default")
-	EHathoraCloudRegion Region;
+	EHathoraCloudRegion Region = EHathoraCloudRegion::Unknown;
 
 	// Unique identifier to a game session or match.
 	UPROPERTY(BlueprintReadOnly, Category = "Default")
@@ -109,8 +108,8 @@ public:
 	// managing the state of a match, and retrieving a list of public lobbies to display to players.
 	// @param Visibility Types of lobbies a player can create.
 	// @param RoomConfig Optional configuration parameters for the room. Can be
-	//                    any string including stringified JSON. It is accessible
-	//                    from the room via GetRoomInfo().
+	//                   any string including stringified JSON. It is accessible
+	//                   from the room via GetRoomInfo().
 	// @param Region The region to create the room in.
 	// @param ShortCode Optional user-defined identifier for a lobby. Leave empty
 	//                  to reference the lobby using the RoomId only.
@@ -129,14 +128,18 @@ public:
 	UDELEGATE()
 	DECLARE_DYNAMIC_DELEGATE_OneParam(FHathoraOnLobbyInfos, FHathoraLobbyInfosResult, Result);
 
-	// Get all active lobbies for a given application. Filter the array by optionally passing
-	// in a `Region`. Use this endpoint to display all public lobbies that a player can join
-	// in the game client.
-	// @param Region Filter the returned lobbies by the provided region. Use
-	//               EHathoraCloudRegion::Unknown to return active public lobbies
-	//               in all regions.
+	// Get all public active lobbies for a given application. Use this endpoint to display
+	// all public lobbies that a player can join in the game client. Use
+	// ListRegionActivePublicLobbies() to only see lobbies in a specific region.
 	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | LobbyV3")
-	void ListActivePublicLobbies(EHathoraCloudRegion Region, FHathoraOnLobbyInfos OnComplete);
+	void ListAllActivePublicLobbies(FHathoraOnLobbyInfos OnComplete);
+
+	// Get all active lobbies for a given application, filtered by Region.
+	// Use this endpoint to display all public lobbies that a player can join
+	// in the game client. Use ListAllActivePublicLobbies() to see all lobbies.
+	// @param Region Filter the returned lobbies by the provided region.
+	UFUNCTION(BlueprintCallable, Category = "HathoraSDK | LobbyV3")
+	void ListRegionActivePublicLobbies(EHathoraCloudRegion Region, FHathoraOnLobbyInfos OnComplete);
 
 	// Get details for a lobby.
 	// @param RoomId Unique identifier to a game session or match.

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKRoomV2.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKRoomV2.h
@@ -88,9 +88,6 @@ struct FHathoraRoomConnectionInfoResult
 UENUM(BlueprintType)
 enum class EHathoraRoomStatus : uint8
 {
-	// Could not parse the API response.
-	Unknown,
-
 	// A process is not allocated yet and the room is
 	// waiting to be scheduled.
 	Scheduling,
@@ -103,7 +100,9 @@ enum class EHathoraRoomStatus : uint8
 	Suspended,
 
 	// All associated metadata is deleted.
-	Destroyed
+	Destroyed,
+
+	Unknown UMETA(Hidden)
 };
 
 USTRUCT(BlueprintType)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
@@ -61,8 +61,6 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FHathoraOnGetRegionalPings, FHathoraRegionPing
 UENUM(BlueprintType)
 enum class EHathoraCloudRegion : uint8
 {
-	// Could not parse the region from the API.
-	Unknown,
 	Seattle,
 	Washington_DC,
 	Chicago,
@@ -72,5 +70,6 @@ enum class EHathoraCloudRegion : uint8
 	Singapore,
 	Tokyo,
 	Sydney,
-	Sao_Paulo
+	Sao_Paulo,
+	Unknown UMETA(Hidden)
 };

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
@@ -43,14 +43,16 @@ struct FHathoraSDKSecurity
 
 	FHathoraSDKSecurity() {}
 
-	FHathoraSDKSecurity(FString HathoraDevToken)
+	FHathoraSDKSecurity(FString InAuthToken)
 	{
-		this->HathoraDevToken = HathoraDevToken;
+		this->AuthToken = InAuthToken;
 	}
 
-	// The HathoraDevToken used for the Authorization HTTP header.
+	// The token to use in the Authorization HTTP header in API calls.
+	// This can be either the HathoraDevToken for server/trusted calls,
+	// or the player auth token for client/untrusted calls.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Default")
-	FString HathoraDevToken;
+	FString AuthToken;
 };
 
 UDELEGATE()
@@ -59,6 +61,8 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FHathoraOnGetRegionalPings, FHathoraRegionPing
 UENUM(BlueprintType)
 enum class EHathoraCloudRegion : uint8
 {
+	// Could not parse the region from the API.
+	Unknown,
 	Seattle,
 	Washington_DC,
 	Chicago,


### PR DESCRIPTION
This PR adds support for both LobbyV3 and AuthV1 API services. I added AuthV1 in this PR as it was easier for testing the lobby API.

Part of this PR is renaming `FHathoraSDKSecurity::HathoraDevToken` to just `AuthToken` to support both server and client calls without having a separate variable. Generally, users will use the lobby API by calling `Create Hathora SDK` with the AppId, call a login method, and then call `UHathoraSDK::SetCredentials` to add the token to the Security variable, and finally call lobby-related endpoints. Here's a blueprint example:

![image](https://github.com/hathora/hathora-unreal-sdk/assets/549323/63887f06-265f-4bc6-9038-36851f076139)
