### PR TITLE
Fix issues with GetRegionalPing

### DIFF
--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
@@ -6,8 +6,8 @@
 
 void UHathoraSDKAPI::SetCredentials(FString InAppId, FHathoraSDKSecurity InSecurity)
 {
-	this->AppId = AppId;
-	this->Security = Security;
+	this->AppId = InAppId;
+	this->Security = InSecurity;
 }
 
 void UHathoraSDKAPI::SendRequest(FString Method, FString Endpoint, TFunction<void(FHttpRequestPtr, FHttpResponsePtr, bool)> OnComplete)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKDiscoveryV1.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKDiscoveryV1.cpp
@@ -11,21 +11,21 @@ void UHathoraSDKDiscoveryV1::GetPingServiceEndpoints(const FHathoraOnGetPingServ
 	SendRequest(
 		TEXT("GET"),
 		TEXT("/discovery/v1/ping"),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 	{
-		TArray<FHathoraDiscoveredPingEndpoint> PingEndpoints;
+		TArray<FHathoraDiscoveredPingEndpoint> PingEndpointsResult;
 		if (bSuccess && Response.IsValid())
 		{
-			FJsonObjectConverter::JsonArrayStringToUStruct(Response->GetContentAsString(), &PingEndpoints);
+			FJsonObjectConverter::JsonArrayStringToUStruct(Response->GetContentAsString(), &PingEndpointsResult);
 		}
 		else
 		{
 			UE_LOG(LogHathoraSDK, Warning, TEXT("Could not retrieve ping endpoints"));
 		}
 
-		if (!OnComplete.ExecuteIfBound(PingEndpoints))
+		if (!OnComplete.ExecuteIfBound(PingEndpointsResult))
 		{
-			UE_LOG(LogHathoraSDK, Warning, TEXT("[GetRegionalPings] function pointer was not valid, so OnComplete will not be called"));
+			UE_LOG(LogHathoraSDK, Warning, TEXT("[GetPingServiceEndpoints] function pointer was not valid, so OnComplete will not be called"));
 		}
 	});
 }
@@ -94,7 +94,7 @@ void UHathoraSDKDiscoveryV1::PingEachRegion()
 		FIcmp::IcmpEcho(
 			PingEndpoint.Host,
 			GetDefault<UHathoraSDKConfig>()->GetPingTimeoutSeconds(),
-			[&, PingEndpoint, CompletedPings, PingsToComplete](FIcmpEchoResult Result)
+			[this, PingEndpoint, CompletedPings, PingsToComplete](FIcmpEchoResult Result)
 			{
 				if (Result.Status == EIcmpResponseStatus::Success)
 				{

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
@@ -38,4 +38,10 @@ public:
 
 	UPROPERTY(BlueprintReadOnly)
 	UHathoraSDKDiscoveryV1* DiscoveryV1;
+
+private:
+	FHathoraOnGetRegionalPings OnGetRegionalPingsComplete;
+
+	UFUNCTION()
+	void OnGetRegionalPingsCompleteWrapper(FHathoraRegionPings Result);
 };


### PR DESCRIPTION
This PR fixes two issues with GetRegionalPing:
1. Fixes some compiler errors when cross compiling for Linux. I'll need to go back to my other branches and check for other issues there
2. It ensures that the `UHathoraSDK` instance created in the `GetRegionalPings` static function doesn't get Garbage Collected until a response is returned; the prior implementation left the UObject* dangling with no references, which in some cases can be collected early by GC