### PR TITLE
Add Los_Angeles cloud region

### DIFF
--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
@@ -62,6 +62,7 @@ UENUM(BlueprintType)
 enum class EHathoraCloudRegion : uint8
 {
 	Seattle,
+	Los_Angeles,
 	Washington_DC,
 	Chicago,
 	London,


### PR DESCRIPTION
This PR adds support for the new `Los_Angeles` cloud region:

![image](https://github.com/hathora/hathora-unreal-sdk/assets/549323/0bb58a87-0793-4b08-8626-0ff7d925cd23)
