### PR TITLE
Attempt to parse the JSON error message

### DIFF
--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -11,6 +11,7 @@
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
+#include "Dom/JsonObject.h"
 
 void UHathoraSDK::GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion)
 {
@@ -118,6 +119,32 @@ EHathoraCloudRegion UHathoraSDK::ParseRegion(FString RegionString)
 	{
 		UE_LOG(LogHathoraSDK, Error, TEXT("[ParseRegion] Unknown region: %s"), *RegionString);
 		return EHathoraCloudRegion::Unknown;
+	}
+}
+
+FString UHathoraSDK::ParseErrorMessage(FString Content)
+{
+	TSharedPtr<FJsonObject> OutObject;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+	FJsonSerializer::Deserialize(Reader, OutObject);
+
+	if (OutObject.IsValid())
+	{
+		FString Message;
+		bool bValid = OutObject->TryGetStringField(TEXT("message"), Message);
+
+		if (bValid)
+		{
+			return Message;
+		}
+		else
+		{
+			return Content;
+		}
+	}
+	else
+	{
+		return Content;
 	}
 }
 

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
@@ -2,6 +2,7 @@
 
 #include "HathoraSDKAuthV1.h"
 #include "HathoraSDKModule.h"
+#include "HathoraSDK.h"
 #include "Serialization/JsonSerializer.h"
 
 void UHathoraSDKAuthV1::LoginAnonymous(FHathoraOnLogin OnComplete)
@@ -68,7 +69,7 @@ void UHathoraSDKAuthV1::Login(FString Path, FJsonObject Body, FHathoraOnLogin On
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKLobbyV3.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKLobbyV3.cpp
@@ -112,7 +112,7 @@ void UHathoraSDKLobbyV3::CreateLobby(
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else
@@ -173,7 +173,7 @@ void UHathoraSDKLobbyV3::ListActivePublicLobbies(TArray<TPair<FString, FString>>
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else
@@ -223,7 +223,7 @@ void UHathoraSDKLobbyV3::GetLobbyInfoByRoomId(FString RoomId, FHathoraOnLobbyInf
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else
@@ -273,7 +273,7 @@ void UHathoraSDKLobbyV3::GetLobbyInfoByShortCode(FString ShortCode, FHathoraOnLo
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKProcessesV1.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKProcessesV1.cpp
@@ -60,7 +60,7 @@ void UHathoraSDKProcessesV1::GetProcesses(bool bRunning, TArray<TPair<FString, F
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else
@@ -110,7 +110,7 @@ void UHathoraSDKProcessesV1::GetProcessInfo(FString ProcessId, FHathoraOnProcess
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKRoomV2.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKRoomV2.cpp
@@ -42,7 +42,7 @@ void UHathoraSDKRoomV2::CreateRoom(EHathoraCloudRegion Region, FString RoomConfi
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else
@@ -159,7 +159,7 @@ void UHathoraSDKRoomV2::GetRoomInfo(FString RoomId, FHathoraOnGetRoomInfo OnComp
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else
@@ -232,7 +232,7 @@ void UHathoraSDKRoomV2::GetRoomsForProcess(FString ProcessId, bool bActive, FHat
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else
@@ -267,7 +267,7 @@ void UHathoraSDKRoomV2::DestroyRoom(FString RoomId, FHathoraOnDestroyRoom OnComp
 
 				if (!Result.bDestroyed)
 				{
-					Result.ErrorMessage = Response->GetContentAsString();
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Response->GetContentAsString());
 				}
 			}
 			else
@@ -302,7 +302,7 @@ void UHathoraSDKRoomV2::SuspendRoom(FString RoomId, FHathoraOnSuspendRoom OnComp
 
 				if (!Result.bSuspended)
 				{
-					Result.ErrorMessage = Response->GetContentAsString();
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Response->GetContentAsString());
 				}
 			}
 			else
@@ -341,7 +341,7 @@ void UHathoraSDKRoomV2::GetConnectionInfo(FString RoomId, FHathoraOnRoomConnecti
 				}
 				else
 				{
-					Result.ErrorMessage = Content;
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Content);
 				}
 			}
 			else
@@ -380,7 +380,7 @@ void UHathoraSDKRoomV2::UpdateRoomConfig(FString RoomId, FString RoomConfig, FHa
 
 				if (!Result.bUpdated)
 				{
-					Result.ErrorMessage = Response->GetContentAsString();
+					Result.ErrorMessage = UHathoraSDK::ParseErrorMessage(Response->GetContentAsString());
 				}
 			}
 			else

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
@@ -44,6 +44,9 @@ public:
 	UFUNCTION(BlueprintPure, Category = "HathoraSDK")
 	static EHathoraCloudRegion ParseRegion(FString RegionString);
 
+	UFUNCTION(BlueprintPure, Category = "HathoraSDK")
+	static FString ParseErrorMessage(FString Content);
+
 	// Set the auth token to use for all requests; primarily on the
 	// client after the player has logged in.
 	// @param Token The JWT auth token to use for all requests.


### PR DESCRIPTION
This PR will attempt to parse error messages returned by Hathora Cloud APIs with the JSON type `{ message: string }`. If the body is not a JSON object (even though it should given recent backend changes) and the `message` is not a string (booleans will still return a valid string: `"message": true` will parse out `"true"` due to Unreal's JSON logic), the whole string passed to `UHathoraSDK::ParseErrorMessage` will be returned as a fallback.