### PR TITLE
Fix crashes related to objects being destroyed during level/world transition

### DIFF
--- a/SDKDemo/Content/W_LobbyMenu.uasset
+++ b/SDKDemo/Content/W_LobbyMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5bc796152ece6c39ab4b0afdedc16a207186a4e0f879178efe80b0f0314e7456
-size 558212
+oid sha256:27baf639cdc1caf6589f6617913c00addc9797165c7d01c13198cd1ff1f61b6d
+size 564000

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
@@ -45,6 +45,12 @@ void UHathoraSDKAPI::SendRequest(
 	FJsonObject Body,
 	TFunction<void(FHttpRequestPtr, FHttpResponsePtr, bool)> OnComplete)
 {
+	if (!IsValid(this))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("Could not make %s request to %s because the underlying Hathora API object is not valid."), *Method, *Endpoint);
+		return;
+	}
+
 	FHttpRequestRef Request = FHttpModule::Get().CreateRequest();
 
 	Request->SetVerb(Method);

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
@@ -5,6 +5,13 @@
 #include "HathoraSDKModule.h"
 #include "HttpModule.h"
 #include "JsonObjectWrapper.h"
+#include "Engine/World.h"
+
+UHathoraSDKAPI::UHathoraSDKAPI(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+	FWorldDelegates::PreLevelRemovedFromWorld.AddUObject(this, &UHathoraSDKAPI::OnWorldRemoved);
+}
 
 void UHathoraSDKAPI::SetCredentials(FString InAppId, FHathoraSDKSecurity InSecurity)
 {
@@ -45,6 +52,12 @@ void UHathoraSDKAPI::SendRequest(
 	FJsonObject Body,
 	TFunction<void(FHttpRequestPtr, FHttpResponsePtr, bool)> OnComplete)
 {
+	if (bWorldIsBeingDestroyed)
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("Could not make %s request to %s because the world is being destroyed."), *Method, *Endpoint);
+		return;
+	}
+
 	if (!IsValid(this))
 	{
 		UE_LOG(LogHathoraSDK, Error, TEXT("Could not make %s request to %s because the underlying Hathora API object is not valid."), *Method, *Endpoint);
@@ -55,7 +68,18 @@ void UHathoraSDKAPI::SendRequest(
 
 	Request->SetVerb(Method);
 
-	Request->OnProcessRequestComplete().BindLambda(OnComplete);
+	Request->OnProcessRequestComplete().BindLambda(
+		[this, Method, Endpoint, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+		{
+			if (bWorldIsBeingDestroyed)
+			{
+				UE_LOG(LogHathoraSDK, Error, TEXT("Could not call OnComplete for %s request to %s because the world is being destroyed."), *Method, *Endpoint);
+				return;
+			}
+
+			OnComplete(Request, Response, bWasSuccessful);
+		}
+	);
 
 	FString QueryString = "?";
 	for (auto QueryOption : QueryOptions) {
@@ -90,4 +114,10 @@ void UHathoraSDKAPI::SendRequest(
 	}
 
 	Request->ProcessRequest();
+}
+
+void UHathoraSDKAPI::OnWorldRemoved(ULevel* Level, UWorld* World)
+{
+	bWorldIsBeingDestroyed = true;
+	FWorldDelegates::PreLevelRemovedFromWorld.RemoveAll(this);
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAuthV1.cpp
@@ -44,7 +44,7 @@ void UHathoraSDKAuthV1::Login(FString Path, FJsonObject Body, FHathoraOnLogin On
 		TEXT("POST"),
 		Path,
 		Body,
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraLoginResult Result;
 			if (bSuccess && Response.IsValid())

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKLobbyV3.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKLobbyV3.cpp
@@ -87,7 +87,7 @@ void UHathoraSDKLobbyV3::CreateLobby(
 		FString::Printf(TEXT("/lobby/v3/%s/create"), *AppId),
 		QueryOptions,
 		Body,
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraLobbyInfoResult Result;
 			if (bSuccess && Response.IsValid())
@@ -151,7 +151,7 @@ void UHathoraSDKLobbyV3::ListActivePublicLobbies(TArray<TPair<FString, FString>>
 		TEXT("GET"),
 		FString::Printf(TEXT("/lobby/v3/%s/list/public"), *AppId),
 		QueryOptions,
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraLobbyInfosResult Result;
 			if (bSuccess && Response.IsValid())
@@ -198,7 +198,7 @@ void UHathoraSDKLobbyV3::GetLobbyInfoByRoomId(FString RoomId, FHathoraOnLobbyInf
 	SendRequest(
 		TEXT("GET"),
 		FString::Printf(TEXT("/lobby/v3/%s/info/roomid/%s"), *AppId, *RoomId),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraLobbyInfoResult Result;
 			if (bSuccess && Response.IsValid())
@@ -248,7 +248,7 @@ void UHathoraSDKLobbyV3::GetLobbyInfoByShortCode(FString ShortCode, FHathoraOnLo
 	SendRequest(
 		TEXT("GET"),
 		FString::Printf(TEXT("/lobby/v3/%s/info/shortcode/%s"), *AppId, *ShortCode),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraLobbyInfoResult Result;
 			if (bSuccess && Response.IsValid())

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKProcessesV1.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKProcessesV1.cpp
@@ -38,7 +38,7 @@ void UHathoraSDKProcessesV1::GetProcesses(bool bRunning, TArray<TPair<FString, F
 		TEXT("GET"),
 		FString::Printf(TEXT("/processes/v1/%s/list/%s"), *AppId, bRunning ? TEXT("running") : TEXT("stopped")),
 		QueryOptions,
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[bRunning, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraProcessInfosResult Result;
 			if (bSuccess && Response.IsValid())
@@ -85,7 +85,7 @@ void UHathoraSDKProcessesV1::GetProcessInfo(FString ProcessId, FHathoraOnProcess
 	SendRequest(
 		TEXT("GET"),
 		FString::Printf(TEXT("/processes/v1/%s/info/%s"), *AppId, *ProcessId),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraProcessInfoResult Result;
 			if (bSuccess && Response.IsValid())

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKRoomV2.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKRoomV2.cpp
@@ -28,7 +28,7 @@ void UHathoraSDKRoomV2::CreateRoom(EHathoraCloudRegion Region, FString RoomConfi
 		FString::Printf(TEXT("/rooms/v2/%s/create"), *AppId),
 		QueryOptions,
 		Body,
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraRoomConnectionInfoResult Result;
 			if (bSuccess && Response.IsValid())
@@ -116,7 +116,7 @@ void UHathoraSDKRoomV2::GetRoomInfo(FString RoomId, FHathoraOnGetRoomInfo OnComp
 	SendRequest(
 		TEXT("GET"),
 		FString::Printf(TEXT("/rooms/v2/%s/info/%s"), *AppId, *RoomId),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraGetRoomInfoResult Result;
 			if (bSuccess && Response.IsValid())
@@ -194,7 +194,7 @@ void UHathoraSDKRoomV2::GetRoomsForProcess(FString ProcessId, bool bActive, FHat
 	SendRequest(
 		TEXT("GET"),
 		FString::Printf(TEXT("/rooms/v2/%s/list/%s/%s"), *AppId, *ProcessId, bActive ? TEXT("active") : TEXT("inactive")),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraGetRoomsForProcessResult Result;
 			if (bSuccess && Response.IsValid())
@@ -257,7 +257,7 @@ void UHathoraSDKRoomV2::DestroyRoom(FString RoomId, FHathoraOnDestroyRoom OnComp
 	SendRequest(
 		TEXT("POST"),
 		FString::Printf(TEXT("/rooms/v2/%s/destroy/%s"), *AppId, *RoomId),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraDestroyRoomResult Result;
 			if (bSuccess && Response.IsValid())
@@ -292,7 +292,7 @@ void UHathoraSDKRoomV2::SuspendRoom(FString RoomId, FHathoraOnSuspendRoom OnComp
 	SendRequest(
 		TEXT("POST"),
 		FString::Printf(TEXT("/rooms/v2/%s/suspend/%s"), *AppId, *RoomId),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraSuspendRoomResult Result;
 			if (bSuccess && Response.IsValid())
@@ -327,7 +327,7 @@ void UHathoraSDKRoomV2::GetConnectionInfo(FString RoomId, FHathoraOnRoomConnecti
 	SendRequest(
 		TEXT("GET"),
 		FString::Printf(TEXT("/rooms/v2/%s/connectioninfo/%s"), *AppId, *RoomId),
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraRoomConnectionInfoResult Result;
 			if (bSuccess && Response.IsValid())
@@ -370,7 +370,7 @@ void UHathoraSDKRoomV2::UpdateRoomConfig(FString RoomId, FString RoomConfig, FHa
 		TEXT("POST"),
 		FString::Printf(TEXT("/rooms/v2/%s/update/%s"), *AppId, *RoomId),
 		Body,
-		[&, OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
+		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
 		{
 			FHathoraUpdateRoomConfigResult Result;
 			if (bSuccess && Response.IsValid())

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/AuthV1/HathoraAuthV1LoginAnonymous.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/AuthV1/HathoraAuthV1LoginAnonymous.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/AuthV1/HathoraAuthV1LoginAnonymous.h"
+#include "HathoraSDKModule.h"
 
 UHathoraAuthV1LoginAnonymous *UHathoraAuthV1LoginAnonymous::LoginAnonymous(
 	UHathoraSDKAuthV1 *HathoraSDKAuthV1,
@@ -14,6 +15,18 @@ UHathoraAuthV1LoginAnonymous *UHathoraAuthV1LoginAnonymous::LoginAnonymous(
 
 void UHathoraAuthV1LoginAnonymous::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKAuthV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("LoginAnonymous failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKAuthV1->LoginAnonymous(
 		UHathoraSDKAuthV1::FHathoraOnLogin::CreateLambda(
 			[this](const FHathoraLoginResult& Result)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/AuthV1/HathoraAuthV1LoginGoogle.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/AuthV1/HathoraAuthV1LoginGoogle.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/AuthV1/HathoraAuthV1LoginGoogle.h"
+#include "HathoraSDKModule.h"
 
 UHathoraAuthV1LoginGoogle *UHathoraAuthV1LoginGoogle::LoginGoogle(
 	UHathoraSDKAuthV1 *HathoraSDKAuthV1,
@@ -16,6 +17,18 @@ UHathoraAuthV1LoginGoogle *UHathoraAuthV1LoginGoogle::LoginGoogle(
 
 void UHathoraAuthV1LoginGoogle::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKAuthV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("LoginGoogle failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKAuthV1->LoginGoogle(
 		IdToken,
 		UHathoraSDKAuthV1::FHathoraOnLogin::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/AuthV1/HathoraAuthV1LoginNickname.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/AuthV1/HathoraAuthV1LoginNickname.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/AuthV1/HathoraAuthV1LoginNickname.h"
+#include "HathoraSDKModule.h"
 
 UHathoraAuthV1LoginNickname *UHathoraAuthV1LoginNickname::LoginNickname(
 	UHathoraSDKAuthV1 *HathoraSDKAuthV1,
@@ -16,6 +17,18 @@ UHathoraAuthV1LoginNickname *UHathoraAuthV1LoginNickname::LoginNickname(
 
 void UHathoraAuthV1LoginNickname::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKAuthV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("LoginNickname failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKAuthV1->LoginNickname(
 		Nickname,
 		UHathoraSDKAuthV1::FHathoraOnLogin::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/DiscoveryV1/HathoraDiscoveryV1GetPingServiceEndpoints.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/DiscoveryV1/HathoraDiscoveryV1GetPingServiceEndpoints.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/DiscoveryV1/HathoraDiscoveryV1GetPingServiceEndpoints.h"
+#include "HathoraSDKModule.h"
 
 UHathoraDiscoveryV1GetPingServiceEndpoints *UHathoraDiscoveryV1GetPingServiceEndpoints::GetPingServiceEndpoints(
 	UHathoraSDKDiscoveryV1 *HathoraSDKDiscoveryV1,
@@ -14,6 +15,18 @@ UHathoraDiscoveryV1GetPingServiceEndpoints *UHathoraDiscoveryV1GetPingServiceEnd
 
 void UHathoraDiscoveryV1GetPingServiceEndpoints::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKDiscoveryV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetPingServiceEndpoints failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKDiscoveryV1->GetPingServiceEndpoints(
 		UHathoraSDKDiscoveryV1::FHathoraOnGetPingServiceEndpoints::CreateLambda(
 			[this](const TArray<FHathoraDiscoveredPingEndpoint>& Endpoints)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/HathoraGetRegionalPings.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/HathoraGetRegionalPings.cpp
@@ -2,6 +2,7 @@
 
 #include "LatentActions/HathoraGetRegionalPings.h"
 #include "HathoraSDK.h"
+#include "HathoraSDKModule.h"
 
 UHathoraGetRegionalPings *UHathoraGetRegionalPings::GetRegionalPings(
 	UObject *WorldContextObject,
@@ -15,6 +16,12 @@ UHathoraGetRegionalPings *UHathoraGetRegionalPings::GetRegionalPings(
 
 void UHathoraGetRegionalPings::Activate()
 {
+	if (!IsValid(this))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetRegionalPings failed because the underlying Hathora API is not valid."));
+		return;
+	}
+
 	UHathoraSDK::GetRegionalPings(
 		FHathoraOnGetRegionalPings::CreateLambda(
 			[this](const FHathoraRegionPings& Result)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3CreateLobby.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3CreateLobby.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/LobbyV3/HathoraLobbyV3CreateLobby.h"
+#include "HathoraSDKModule.h"
 
 UHathoraLobbyV3CreateLobby *UHathoraLobbyV3CreateLobby::CreateLobby(
 	UHathoraSDKLobbyV3 *HathoraSDKLobbyV3,
@@ -24,6 +25,18 @@ UHathoraLobbyV3CreateLobby *UHathoraLobbyV3CreateLobby::CreateLobby(
 
 void UHathoraLobbyV3CreateLobby::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKLobbyV3))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("CreateLobby failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKLobbyV3->CreateLobby(
 		Visibility,
 		RoomConfig,

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3GetLobbyInfoByRoomId.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3GetLobbyInfoByRoomId.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/LobbyV3/HathoraLobbyV3GetLobbyInfoByRoomId.h"
+#include "HathoraSDKModule.h"
 
 UHathoraLobbyV3GetLobbyInfoByRoomId *UHathoraLobbyV3GetLobbyInfoByRoomId::GetLobbyInfoByRoomId(
 	UHathoraSDKLobbyV3 *HathoraSDKLobbyV3,
@@ -16,6 +17,18 @@ UHathoraLobbyV3GetLobbyInfoByRoomId *UHathoraLobbyV3GetLobbyInfoByRoomId::GetLob
 
 void UHathoraLobbyV3GetLobbyInfoByRoomId::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKLobbyV3))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetLobbyInfoByRoomId failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKLobbyV3->GetLobbyInfoByRoomId(
 		RoomId,
 		UHathoraSDKLobbyV3::FHathoraOnLobbyInfo::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3GetLobbyInfoByShortCode.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3GetLobbyInfoByShortCode.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/LobbyV3/HathoraLobbyV3GetLobbyInfoByShortCode.h"
+#include "HathoraSDKModule.h"
 
 UHathoraLobbyV3GetLobbyInfoByShortCode *UHathoraLobbyV3GetLobbyInfoByShortCode::GetLobbyInfoByShortCode(
 	UHathoraSDKLobbyV3 *HathoraSDKLobbyV3,
@@ -16,6 +17,18 @@ UHathoraLobbyV3GetLobbyInfoByShortCode *UHathoraLobbyV3GetLobbyInfoByShortCode::
 
 void UHathoraLobbyV3GetLobbyInfoByShortCode::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKLobbyV3))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetLobbyInfoByShortCode failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKLobbyV3->GetLobbyInfoByShortCode(
 		ShortCode,
 		UHathoraSDKLobbyV3::FHathoraOnLobbyInfo::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3ListAllActivePublicLobbies.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3ListAllActivePublicLobbies.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/LobbyV3/HathoraLobbyV3ListAllActivePublicLobbies.h"
+#include "HathoraSDKModule.h"
 
 UHathoraLobbyV3ListAllActivePublicLobbies *UHathoraLobbyV3ListAllActivePublicLobbies::ListAllActivePublicLobbies(
 	UHathoraSDKLobbyV3 *HathoraSDKLobbyV3,
@@ -14,6 +15,18 @@ UHathoraLobbyV3ListAllActivePublicLobbies *UHathoraLobbyV3ListAllActivePublicLob
 
 void UHathoraLobbyV3ListAllActivePublicLobbies::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKLobbyV3))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("ListAllActivePublicLobbies failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKLobbyV3->ListAllActivePublicLobbies(
 		UHathoraSDKLobbyV3::FHathoraOnLobbyInfos::CreateLambda(
 			[this](const FHathoraLobbyInfosResult& Result)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3ListRegionActivePublicLobbies.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/LobbyV3/HathoraLobbyV3ListRegionActivePublicLobbies.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/LobbyV3/HathoraLobbyV3ListRegionActivePublicLobbies.h"
+#include "HathoraSDKModule.h"
 
 UHathoraLobbyV3ListRegionActivePublicLobbies *UHathoraLobbyV3ListRegionActivePublicLobbies::ListRegionActivePublicLobbies(
 	UHathoraSDKLobbyV3 *HathoraSDKLobbyV3,
@@ -16,6 +17,18 @@ UHathoraLobbyV3ListRegionActivePublicLobbies *UHathoraLobbyV3ListRegionActivePub
 
 void UHathoraLobbyV3ListRegionActivePublicLobbies::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKLobbyV3))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("ListRegionActivePublicLobbies failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKLobbyV3->ListRegionActivePublicLobbies(
 		Region,
 		UHathoraSDKLobbyV3::FHathoraOnLobbyInfos::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetAllRunningProcesses.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetAllRunningProcesses.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/ProcessesV1/HathoraProcessesV1GetAllRunningProcesses.h"
+#include "HathoraSDKModule.h"
 
 UHathoraProcessesV1GetAllRunningProcesses *UHathoraProcessesV1GetAllRunningProcesses::GetAllRunningProcesses(
 	UHathoraSDKProcessesV1 *HathoraSDKProcessesV1,
@@ -14,6 +15,18 @@ UHathoraProcessesV1GetAllRunningProcesses *UHathoraProcessesV1GetAllRunningProce
 
 void UHathoraProcessesV1GetAllRunningProcesses::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKProcessesV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetAllRunningProcesses failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKProcessesV1->GetAllRunningProcesses(
 		UHathoraSDKProcessesV1::FHathoraOnProcessInfos::CreateLambda(
 			[this](const FHathoraProcessInfosResult& Result)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetAllStoppedProcesses.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetAllStoppedProcesses.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/ProcessesV1/HathoraProcessesV1GetAllStoppedProcesses.h"
+#include "HathoraSDKModule.h"
 
 UHathoraProcessesV1GetAllStoppedProcesses *UHathoraProcessesV1GetAllStoppedProcesses::GetAllStoppedProcesses(
 	UHathoraSDKProcessesV1 *HathoraSDKProcessesV1,
@@ -14,6 +15,18 @@ UHathoraProcessesV1GetAllStoppedProcesses *UHathoraProcessesV1GetAllStoppedProce
 
 void UHathoraProcessesV1GetAllStoppedProcesses::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKProcessesV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetAllStoppedProcesses failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKProcessesV1->GetAllStoppedProcesses(
 		UHathoraSDKProcessesV1::FHathoraOnProcessInfos::CreateLambda(
 			[this](const FHathoraProcessInfosResult& Result)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetProcessInfo.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetProcessInfo.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/ProcessesV1/HathoraProcessesV1GetProcessInfo.h"
+#include "HathoraSDKModule.h"
 
 UHathoraProcessesV1GetProcessInfo *UHathoraProcessesV1GetProcessInfo::GetProcessInfo(
 	UHathoraSDKProcessesV1 *HathoraSDKProcessesV1,
@@ -16,6 +17,18 @@ UHathoraProcessesV1GetProcessInfo *UHathoraProcessesV1GetProcessInfo::GetProcess
 
 void UHathoraProcessesV1GetProcessInfo::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKProcessesV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetProcessInfo failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKProcessesV1->GetProcessInfo(
 		ProcessId,
 		UHathoraSDKProcessesV1::FHathoraOnProcessInfo::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetRegionRunningProcesses.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetRegionRunningProcesses.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/ProcessesV1/HathoraProcessesV1GetRegionRunningProcesses.h"
+#include "HathoraSDKModule.h"
 
 UHathoraProcessesV1GetRegionRunningProcesses *UHathoraProcessesV1GetRegionRunningProcesses::GetRegionRunningProcesses(
 	UHathoraSDKProcessesV1 *HathoraSDKProcessesV1,
@@ -16,6 +17,18 @@ UHathoraProcessesV1GetRegionRunningProcesses *UHathoraProcessesV1GetRegionRunnin
 
 void UHathoraProcessesV1GetRegionRunningProcesses::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKProcessesV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetRegionRunningProcesses failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKProcessesV1->GetRegionRunningProcesses(
 		Region,
 		UHathoraSDKProcessesV1::FHathoraOnProcessInfos::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetRegionStoppedProcesses.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/ProcessesV1/HathoraProcessesV1GetRegionStoppedProcesses.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/ProcessesV1/HathoraProcessesV1GetRegionStoppedProcesses.h"
+#include "HathoraSDKModule.h"
 
 UHathoraProcessesV1GetRegionStoppedProcesses *UHathoraProcessesV1GetRegionStoppedProcesses::GetRegionStoppedProcesses(
 	UHathoraSDKProcessesV1 *HathoraSDKProcessesV1,
@@ -16,6 +17,18 @@ UHathoraProcessesV1GetRegionStoppedProcesses *UHathoraProcessesV1GetRegionStoppe
 
 void UHathoraProcessesV1GetRegionStoppedProcesses::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKProcessesV1))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetRegionStoppedProcesses failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKProcessesV1->GetRegionStoppedProcesses(
 		Region,
 		UHathoraSDKProcessesV1::FHathoraOnProcessInfos::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2CreateRoom.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2CreateRoom.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/RoomV2/HathoraRoomV2CreateRoom.h"
+#include "HathoraSDKModule.h"
 
 UHathoraRoomV2CreateRoom *UHathoraRoomV2CreateRoom::CreateRoom(
 	UHathoraSDKRoomV2 *HathoraSDKRoomV2,
@@ -20,6 +21,18 @@ UHathoraRoomV2CreateRoom *UHathoraRoomV2CreateRoom::CreateRoom(
 
 void UHathoraRoomV2CreateRoom::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKRoomV2))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("CreateRoom failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKRoomV2->CreateRoom(
 		Region,
 		RoomConfig,

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2DestroyRoom.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2DestroyRoom.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/RoomV2/HathoraRoomV2DestroyRoom.h"
+#include "HathoraSDKModule.h"
 
 UHathoraRoomV2DestroyRoom *UHathoraRoomV2DestroyRoom::DestroyRoom(
 	UHathoraSDKRoomV2 *HathoraSDKRoomV2,
@@ -16,6 +17,18 @@ UHathoraRoomV2DestroyRoom *UHathoraRoomV2DestroyRoom::DestroyRoom(
 
 void UHathoraRoomV2DestroyRoom::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKRoomV2))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("DestroyRoom failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKRoomV2->DestroyRoom(
 		RoomId,
 		UHathoraSDKRoomV2::FHathoraOnDestroyRoom::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2GetActiveRoomsForProcess.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2GetActiveRoomsForProcess.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/RoomV2/HathoraRoomV2GetActiveRoomsForProcess.h"
+#include "HathoraSDKModule.h"
 
 UHathoraRoomV2GetActiveRoomsForProcess *UHathoraRoomV2GetActiveRoomsForProcess::GetActiveRoomsForProcess(
 	UHathoraSDKRoomV2 *HathoraSDKRoomV2,
@@ -16,6 +17,18 @@ UHathoraRoomV2GetActiveRoomsForProcess *UHathoraRoomV2GetActiveRoomsForProcess::
 
 void UHathoraRoomV2GetActiveRoomsForProcess::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKRoomV2))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetActiveRoomsForProcess failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKRoomV2->GetActiveRoomsForProcess(
 		ProcessId,
 		UHathoraSDKRoomV2::FHathoraOnGetRoomsForProcess::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2GetConnectionInfo.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2GetConnectionInfo.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/RoomV2/HathoraRoomV2GetConnectionInfo.h"
+#include "HathoraSDKModule.h"
 
 UHathoraRoomV2GetConnectionInfo *UHathoraRoomV2GetConnectionInfo::GetConnectionInfo(
 	UHathoraSDKRoomV2 *HathoraSDKRoomV2,
@@ -16,6 +17,18 @@ UHathoraRoomV2GetConnectionInfo *UHathoraRoomV2GetConnectionInfo::GetConnectionI
 
 void UHathoraRoomV2GetConnectionInfo::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKRoomV2))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetConnectionInfo failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKRoomV2->GetConnectionInfo(
 		RoomId,
 		UHathoraSDKRoomV2::FHathoraOnRoomConnectionInfo::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2GetInactiveRoomsForProcess.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2GetInactiveRoomsForProcess.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/RoomV2/HathoraRoomV2GetInactiveRoomsForProcess.h"
+#include "HathoraSDKModule.h"
 
 UHathoraRoomV2GetInactiveRoomsForProcess *UHathoraRoomV2GetInactiveRoomsForProcess::GetInactiveRoomsForProcess(
 	UHathoraSDKRoomV2 *HathoraSDKRoomV2,
@@ -16,6 +17,18 @@ UHathoraRoomV2GetInactiveRoomsForProcess *UHathoraRoomV2GetInactiveRoomsForProce
 
 void UHathoraRoomV2GetInactiveRoomsForProcess::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKRoomV2))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetInactiveRoomsForProcess failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKRoomV2->GetInactiveRoomsForProcess(
 		ProcessId,
 		UHathoraSDKRoomV2::FHathoraOnGetRoomsForProcess::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2GetRoomInfo.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2GetRoomInfo.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/RoomV2/HathoraRoomV2GetRoomInfo.h"
+#include "HathoraSDKModule.h"
 
 UHathoraRoomV2GetRoomInfo *UHathoraRoomV2GetRoomInfo::GetRoomInfo(
 	UHathoraSDKRoomV2 *HathoraSDKRoomV2,
@@ -16,6 +17,18 @@ UHathoraRoomV2GetRoomInfo *UHathoraRoomV2GetRoomInfo::GetRoomInfo(
 
 void UHathoraRoomV2GetRoomInfo::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKRoomV2))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetRoomInfo failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKRoomV2->GetRoomInfo(
 		RoomId,
 		UHathoraSDKRoomV2::FHathoraOnGetRoomInfo::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2SuspendRoom.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2SuspendRoom.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/RoomV2/HathoraRoomV2SuspendRoom.h"
+#include "HathoraSDKModule.h"
 
 UHathoraRoomV2SuspendRoom *UHathoraRoomV2SuspendRoom::SuspendRoom(
 	UHathoraSDKRoomV2 *HathoraSDKRoomV2,
@@ -16,6 +17,18 @@ UHathoraRoomV2SuspendRoom *UHathoraRoomV2SuspendRoom::SuspendRoom(
 
 void UHathoraRoomV2SuspendRoom::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKRoomV2))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("SuspendRoom failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKRoomV2->SuspendRoom(
 		RoomId,
 		UHathoraSDKRoomV2::FHathoraOnSuspendRoom::CreateLambda(

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2UpdateRoomConfig.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/RoomV2/HathoraRoomV2UpdateRoomConfig.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "LatentActions/RoomV2/HathoraRoomV2UpdateRoomConfig.h"
+#include "HathoraSDKModule.h"
 
 UHathoraRoomV2UpdateRoomConfig *UHathoraRoomV2UpdateRoomConfig::UpdateRoomConfig(
 	UHathoraSDKRoomV2 *HathoraSDKRoomV2,
@@ -18,6 +19,18 @@ UHathoraRoomV2UpdateRoomConfig *UHathoraRoomV2UpdateRoomConfig::UpdateRoomConfig
 
 void UHathoraRoomV2UpdateRoomConfig::Activate()
 {
+	if (!IsValid(this) || !IsValid(HathoraSDKRoomV2))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("UpdateRoomConfig failed because the underlying Hathora API is not valid."));
+
+		if (IsValid(this))
+		{
+			SetReadyToDestroy();
+		}
+
+		return;
+	}
+
 	HathoraSDKRoomV2->UpdateRoomConfig(
 		RoomId,
 		RoomConfig,

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraLobbyComponent.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraLobbyComponent.h
@@ -65,7 +65,9 @@ public:
 	FLobbyComponentLobbyReady OnLobbyReady;
 
 private:
+	UPROPERTY()
 	UHathoraSDK* SDK = nullptr;
+
 	FString JoinRoomIdWhenReady;
 	TMap<FString, FHathoraConnectionInfo> PreReadyLobbies;
 

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKAPI.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKAPI.h
@@ -13,7 +13,7 @@
 UCLASS(BlueprintType)
 class HATHORASDK_API UHathoraSDKAPI : public UBlueprintFunctionLibrary
 {
-	GENERATED_BODY()
+	GENERATED_UCLASS_BODY()
 
 public:
 	void SetCredentials(FString AppId, FHathoraSDKSecurity Security);
@@ -47,6 +47,12 @@ protected:
 		TFunction<void(FHttpRequestPtr, FHttpResponsePtr, bool)> OnProcessRequestComplete
 	);
 
+	UFUNCTION()
+	void OnWorldRemoved(ULevel* Level, UWorld* World);
+
 	FString AppId;
 	FHathoraSDKSecurity Security;
+
+	bool bIsBoundToWorldRemoving = false;
+	bool bWorldIsBeingDestroyed = false;
 };


### PR DESCRIPTION
This PR fixes adds several checks around the codebase to prevent executing functions if an object is invalid (probably because the world is being destroyed) or if the world is explicitly being destroyed. The world being destroyed can happen when the game is exiting, but it can also happen during loading another world/level/map/server. I was seeing this error when I would hit the Refresh button on the lobby widget several times just after clicking the Join button to load a level. The world would be valid before the network request, but be invalid after the network request and objects started getting destroyed. Unfortunately not everything gets destroyed in time, causing an access violation exception.

The simplest fix added by this PR is by checking `IsValid(UObject* Object)` everywhere it seems relevant. This was probably an excessive amount, but I'd rather there be more checks than have customer games that crash. This checks `Object != nullptr` as well to see if `Object` is pending kill or garbage collection.

However, we still had some edge cases still causing a crash with the same reproduction steps. The most impactful change however was binding to `FWorldDelegates::PreLevelRemovedFromWorld` in `UHathoraSDKAPI` (which all of the SDK API classes inherit from) to be able to set a flag when the world starts being destroyed. We then prevent sending any new requests or executing callbacks after responses if this flag has been set. This prevents the functions that were causing the access violation from ever being called the moment the world begins to be destroyed.