### PR TITLE
Fix issues on how `UHathoraSDKAPI` handles world destruction

### DIFF
--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKAPI.cpp
@@ -10,7 +10,10 @@
 UHathoraSDKAPI::UHathoraSDKAPI(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
-	FWorldDelegates::PreLevelRemovedFromWorld.AddUObject(this, &UHathoraSDKAPI::OnWorldRemoved);
+	if (!HasAnyFlags(RF_ClassDefaultObject))
+	{
+		FWorldDelegates::PreLevelRemovedFromWorld.AddUObject(this, &UHathoraSDKAPI::OnWorldRemoved);
+	}
 }
 
 void UHathoraSDKAPI::SetCredentials(FString InAppId, FHathoraSDKSecurity InSecurity)
@@ -118,6 +121,9 @@ void UHathoraSDKAPI::SendRequest(
 
 void UHathoraSDKAPI::OnWorldRemoved(ULevel* Level, UWorld* World)
 {
-	bWorldIsBeingDestroyed = true;
-	FWorldDelegates::PreLevelRemovedFromWorld.RemoveAll(this);
+	if (World != nullptr && GetWorld() == World)
+	{
+		bWorldIsBeingDestroyed = true;
+		FWorldDelegates::PreLevelRemovedFromWorld.RemoveAll(this);
+	}
 }


### PR DESCRIPTION
During PIE (Play In Editor) world startup, UE will trigger `FWorldDelegates::PreLevelRemovedFromWorld` events to be fired for null worlds (see more details [here](https://forums.unrealengine.com/t/fworlddelegates-bug/338139)). This can be triggered in other scenarios too (i.e. level streaming). This issue is easily reproduced by running the `MainLevel` level in Net Mode `Client` with 2 or more clients and trying to press the `Login` button; only one client will succeed.

This PR ensures that we only stop processing API requests when the main persistent level (via `GetWorld()`) is being destroyed.

This PR also ensures that we don't bind for world destruction events when `UHathoraSDKAPI` is being created as part of a CDO (aka Class Default Object). Construction still occurs when initializing a CDO, which is created in UE to determine class defaults, without the intent of full object initialization/processing (it's meant to be an ephemeral instance of the class).