### PR TITLE
Deprecate `GetRegionalPings` for new `GetPingsForRegions` method

### DIFF
--- a/SDKDemo/Content/W_LobbyMenu.uasset
+++ b/SDKDemo/Content/W_LobbyMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27baf639cdc1caf6589f6617913c00addc9797165c7d01c13198cd1ff1f61b6d
-size 564000
+oid sha256:24af3526ad9845080a551960a25420404fcb9586b16779cb4d90bb72b0d3fbc9
+size 563251

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraPingUtility.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraPingUtility.cpp
@@ -1,0 +1,115 @@
+// Copyright 2025 Hathora, Inc.
+
+#include "HathoraPingUtility.h"
+#include "HathoraSDKModule.h"
+#include "HathoraSDKConfig.h"
+#include "Icmp.h"
+
+void UHathoraPingUtility::GetPingsForRegions(TMap<FString, FString> InRegionUrls, EHathoraPingType InPingType, const FHathoraOnGetRegionalPings& OnComplete, int32 InNumPingsPerRegion)
+{
+	RegionUrls = InRegionUrls;
+	PingType = InPingType;
+	OnGetRegionalPingsComplete = OnComplete;
+	NumPingsPerRegion = InNumPingsPerRegion;
+	NumPingsPerRegionCompleted = 0;
+	PingResults = MakeShared<TMap<FString, TArray<int32>>>();
+	PingEachRegion();
+}
+
+void UHathoraPingUtility::PingEachRegion()
+{
+	// recursively call this function until we have pinged each region
+	// the desired number of times, and then aggregate the results and return
+	// this ensures subsequent pings to a particular region are done sequentially
+	// instead of simultaneously
+	if (NumPingsPerRegionCompleted >= NumPingsPerRegion)
+	{
+		UE_LOG(LogHathoraSDK, Log, TEXT("Completed multiple pings to each Hathora region; returning the averages."));
+
+		FHathoraRegionPings FinalResult;
+
+		for (const TPair<FString, TArray<int32>>& PingResult : *PingResults)
+		{
+			int32 Min = -1;
+			for (int32 PingTime : PingResult.Value)
+			{
+				if (Min == -1 || PingTime < Min)
+				{
+					Min = PingTime;
+				}
+			}
+			FinalResult.Pings.Add(PingResult.Key, Min);
+		}
+
+		OnGetRegionalPingsComplete.ExecuteIfBound(FinalResult);
+
+		return;
+	}
+
+	NumPingsPerRegionCompleted++;
+
+	TSharedPtr<int32> CompletedPings = MakeShared<int32>(0);
+	const int32 PingsToComplete = RegionUrls.Num();
+
+	// ping each region once
+	for (const auto& RegionUrl : RegionUrls)
+	{
+		FString Name = RegionUrl.Key;
+		bool bHasPort = RegionUrl.Value.Contains(":");
+		FString Host = bHasPort ? RegionUrl.Value.Left(RegionUrl.Value.Find(":")) : RegionUrl.Value;
+		int32 Port = bHasPort ? FCString::Atoi(*RegionUrl.Value.RightChop(RegionUrl.Value.Find(":") + 1)) : 443;
+
+		FIcmpEchoResultCallback Callback =
+			[this, Name, Host, CompletedPings, PingsToComplete](FIcmpEchoResult Result)
+			{
+				if (Result.Status == EIcmpResponseStatus::Success)
+				{
+					int32 PingTime = Result.Time * 1000;
+					UE_LOG(LogHathoraSDK, Log, TEXT("Ping to %s (%s) took: %d ms"), *Name, *Host, PingTime);
+					TArray<int32>* RegionPings = PingResults->Find(Name);
+					if (RegionPings == nullptr)
+					{
+						TArray<int32> NewRegionPings;
+						NewRegionPings.Add(PingTime);
+						PingResults->Add(Name, NewRegionPings);
+					}
+					else
+					{
+						RegionPings->Add(PingTime);
+					}
+				}
+				else
+				{
+					UE_LOG(LogHathoraSDK, Warning, TEXT("Ping to %s (%s) failed: %s"), *Name, *Host, LexToString(Result.Status));
+				}
+
+				// Regardless of whether the ping was successful, we will mark it complete.
+				if (++(*CompletedPings) == PingsToComplete)
+				{
+					UE_LOG(LogHathoraSDK, Log, TEXT("Pings to each region complete; triggering another set of pings."));
+					PingEachRegion();
+				}
+			};
+
+		if (PingType == EHathoraPingType::ICMP)
+		{
+			FIcmp::IcmpEcho(
+				Host,
+				GetDefault<UHathoraSDKConfig>()->GetPingTimeoutSeconds(),
+				Callback
+			);
+		}
+		else if (PingType == EHathoraPingType::UDPEcho)
+		{
+			FUDPPing::UDPEcho(
+				RegionUrl.Value,
+				GetDefault<UHathoraSDKConfig>()->GetPingTimeoutSeconds(),
+				Callback
+			);
+		}
+		else
+		{
+			UE_LOG(LogHathoraSDK, Warning, TEXT("Unsupported ping type: %s"), *UEnum::GetValueAsString(PingType));
+		}
+	}
+}

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -42,11 +42,6 @@ UHathoraSDK* UHathoraSDK::CreateHathoraSDK()
 	FString AppId = Config->GetAppId();
 	FHathoraSDKSecurity Security(Config->GetDevToken());
 
-	if (Config->GetDevToken().Len() == 0)
-	{
-		UE_LOG(LogHathoraSDK, Warning, TEXT("No DevToken specified in Game.ini. This is required for server builds."));
-	}
-
 	SDK->SetCredentials(Config->GetAppId(), Security);
 
 	return SDK;

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -8,6 +8,7 @@
 #include "HathoraSDKLobbyV3.h"
 #include "HathoraSDKProcessesV2.h"
 #include "HathoraSDKRoomV2.h"
+#include "HathoraPingUtility.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
@@ -15,18 +16,52 @@
 
 void UHathoraSDK::GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion)
 {
-	UHathoraSDK* SDK = UHathoraSDK::CreateHathoraSDK();
-	SDK->AddToRoot(); // make sure this doesn't get garbage collected
-	SDK->DiscoveryV2->GetRegionalPings(
+	UHathoraSDK::GetPingsForRegions(
+		UHathoraSDK::GetRegionMap(),
+		EHathoraPingType::ICMP,
+		OnComplete,
+		NumPingsPerRegion
+	);
+}
+
+void UHathoraSDK::GetPingsForRegions(TMap<FString, FString> Regions, EHathoraPingType PingType, const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion)
+{
+	UHathoraPingUtility* PingUtility = NewObject<UHathoraPingUtility>();
+	PingUtility->AddToRoot(); // make sure this doesn't get garbage collected
+	PingUtility->GetPingsForRegions(
+		Regions,
+		PingType,
 		FHathoraOnGetRegionalPings::CreateLambda(
-			[OnComplete, SDK](const FHathoraRegionPings& Result)
+			[OnComplete, PingUtility](const FHathoraRegionPings& Result)
 			{
 				OnComplete.ExecuteIfBound(Result);
-				SDK->RemoveFromRoot(); // Allow this SDK reference to be garbage collected
+				PingUtility->RemoveFromRoot(); // Allow this SDK reference to be garbage collected
 			}
 		),
 		NumPingsPerRegion
 	);
+}
+
+TMap<FString, FString> UHathoraSDK::GetRegionMap()
+{
+	TMap<FString, FString> RegionMap;
+
+	RegionMap.Add(TEXT("Chicago"), TEXT("chicago.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Dallas"), TEXT("dallas.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Dubai"), TEXT("dubai.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Frankfurt"), TEXT("frankfurt.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Johannesburg"), TEXT("johannesburg.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("London"), TEXT("london.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Los Angeles"), TEXT("losangeles.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Mumbai"), TEXT("mumbai.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Sao Paulo"), TEXT("saopaulo.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Seattle"), TEXT("seattle.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Singapore"), TEXT("singapore.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Sydney"), TEXT("sydney.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Tokyo"), TEXT("tokyo.ping.hathora.dev:10000"));
+	RegionMap.Add(TEXT("Washington DC"), TEXT("washingtondc.ping.hathora.dev:10000"));
+
+	return RegionMap;
 }
 
 UHathoraSDK* UHathoraSDK::CreateHathoraSDK()

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -59,8 +59,14 @@ FHathoraServerEnvironment UHathoraSDK::GetServerEnvironment()
 	Environment.AppId = FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_APP_ID"));
 	Environment.AppSecret = FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_APP_SECRET"));
 	Environment.ProcessId = FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_PROCESS_ID"));
+	Environment.DeploymentId = FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_DEPLOYMENT_ID"));
+	Environment.BuildTag = FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_BUILD_TAG"));
 	Environment.Region = ParseRegion(FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_REGION")));
 	Environment.RoomsPerProcess = FCString::Atoi(*FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_ROOMS_PER_PROCESS")));
+	Environment.InitialRoomId = FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_INITIAL_ROOM_ID"));
+	Environment.InitialRoomConfig = FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_INITIAL_ROOM_CONFIG"));
+	Environment.Hostname = FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_HOSTNAME"));
+	Environment.DefaultPort = FCString::Atoi(*FPlatformMisc::GetEnvironmentVariable(TEXT("HATHORA_DEFAULT_PORT")));
 
 	return Environment;
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKDiscoveryV2.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKDiscoveryV2.cpp
@@ -1,33 +1,30 @@
 // Copyright 2023 Hathora, Inc.
 
 #include "HathoraSDKDiscoveryV2.h"
+#include "HathoraSDK.h"
 #include "HathoraSDKModule.h"
-#include "HathoraSDKConfig.h"
-#include "JsonObjectConverter.h"
-#include "Icmp.h"
 
 void UHathoraSDKDiscoveryV2::GetPingServiceEndpoints(const FHathoraOnGetPingServiceEndpoints& OnComplete)
 {
-	SendRequest(
-		TEXT("GET"),
-		TEXT("/discovery/v2/ping"),
-		[OnComplete](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess) mutable
-	{
-		TArray<FHathoraDiscoveredPingEndpoint> PingEndpointsResult;
-		if (bSuccess && Response.IsValid())
-		{
-			FJsonObjectConverter::JsonArrayStringToUStruct(Response->GetContentAsString(), &PingEndpointsResult);
-		}
-		else
-		{
-			UE_LOG(LogHathoraSDK, Warning, TEXT("Could not retrieve ping endpoints"));
-		}
+	TArray<FHathoraDiscoveredPingEndpoint> PingEndpointsResult;
+	TMap<FString, FString> RegionUrls = UHathoraSDK::GetRegionMap();
 
-		if (!OnComplete.ExecuteIfBound(PingEndpointsResult))
-		{
-			UE_LOG(LogHathoraSDK, Warning, TEXT("[GetPingServiceEndpoints] function pointer was not valid, so OnComplete will not be called"));
-		}
-	});
+	for (const auto& Region : RegionUrls)
+	{
+		FHathoraDiscoveredPingEndpoint Endpoint;
+		Endpoint.Region = Region.Key;
+
+		bool bHasPort = Region.Value.Contains(":");
+
+		Endpoint.Host = bHasPort ? Region.Value.LeftChop(Region.Value.Find(":")) : Region.Value;
+		Endpoint.Port = bHasPort ? FCString::Atoi(*Region.Value.RightChop(Region.Value.Find(":") + 1)) : 443;
+		PingEndpointsResult.Add(Endpoint);
+	}
+
+	if (!OnComplete.ExecuteIfBound(PingEndpointsResult))
+	{
+		UE_LOG(LogHathoraSDK, Warning, TEXT("[GetPingServiceEndpoints] function pointer was not valid, so OnComplete will not be called"));
+	}
 }
 
 void UHathoraSDKDiscoveryV2::GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 InNumPingsPerRegion)
@@ -38,92 +35,10 @@ void UHathoraSDKDiscoveryV2::GetRegionalPings(const FHathoraOnGetRegionalPings& 
 		InNumPingsPerRegion = 3;
 	}
 
-	OnGetRegionalPingsComplete = OnComplete;
-	NumPingsPerRegion = InNumPingsPerRegion;
-	GetPingServiceEndpoints(
-		UHathoraSDKDiscoveryV2::FHathoraOnGetPingServiceEndpoints::CreateLambda(
-			[this](const TArray<FHathoraDiscoveredPingEndpoint>& Endpoints)
-			{
-				PingEndpoints = Endpoints;
-				NumPingsPerRegionCompleted = 0;
-				PingResults = MakeShared<TMap<FString, TArray<int32>>>();
-				PingEachRegion();
-			}
-		)
+	UHathoraSDK::GetPingsForRegions(
+		UHathoraSDK::GetRegionMap(),
+		EHathoraPingType::ICMP,
+		OnComplete,
+		InNumPingsPerRegion
 	);
-}
-
-void UHathoraSDKDiscoveryV2::PingEachRegion()
-{
-	// recursively call this function until we have pinged each region
-	// the desired number of times, and then aggregate the results and return
-	// this ensures subsequent pings to a particular region are done sequentially
-	// instead of simultaneously
-	if (NumPingsPerRegionCompleted >= NumPingsPerRegion)
-	{
-		UE_LOG(LogHathoraSDK, Log, TEXT("Completed multiple pings to each Hathora region; returning the averages."));
-
-		FHathoraRegionPings FinalResult;
-
-		for (const TPair<FString, TArray<int32>>& PingResult : *PingResults)
-		{
-			int32 Min = -1;
-			for (int32 PingTime : PingResult.Value)
-			{
-				if (Min == -1 || PingTime < Min)
-				{
-					Min = PingTime;
-				}
-			}
-			FinalResult.Pings.Add(PingResult.Key, Min);
-		}
-
-		OnGetRegionalPingsComplete.ExecuteIfBound(FinalResult);
-
-		return;
-	}
-
-	NumPingsPerRegionCompleted++;
-
-	TSharedPtr<int32> CompletedPings = MakeShared<int32>(0);
-	const int32 PingsToComplete = PingEndpoints.Num();
-
-	// ping each region once
-	for (const FHathoraDiscoveredPingEndpoint& PingEndpoint : PingEndpoints)
-	{
-		FIcmp::IcmpEcho(
-			PingEndpoint.Host,
-			GetDefault<UHathoraSDKConfig>()->GetPingTimeoutSeconds(),
-			[this, PingEndpoint, CompletedPings, PingsToComplete](FIcmpEchoResult Result)
-			{
-				if (Result.Status == EIcmpResponseStatus::Success)
-				{
-					int32 PingTime = Result.Time * 1000;
-					UE_LOG(LogHathoraSDK, Log, TEXT("Ping to %s (%s) took: %d ms"), *PingEndpoint.Region, *PingEndpoint.Host, PingTime);
-					TArray<int32>* RegionPings = PingResults->Find(PingEndpoint.Region);
-					if (RegionPings == nullptr)
-					{
-						TArray<int32> NewRegionPings;
-						NewRegionPings.Add(PingTime);
-						PingResults->Add(PingEndpoint.Region, NewRegionPings);
-					}
-					else
-					{
-						RegionPings->Add(PingTime);
-					}
-				}
-				else
-				{
-					UE_LOG(LogHathoraSDK, Warning, TEXT("Ping to %s (%s) failed: %s"), *PingEndpoint.Region, *PingEndpoint.Host, LexToString(Result.Status));
-				}
-
-				// Regardless of whether the ping was successful, we will mark it complete.
-				if (++(*CompletedPings) == PingsToComplete)
-				{
-					UE_LOG(LogHathoraSDK, Log, TEXT("Pings to each region complete; triggering another set of pings."));
-					PingEachRegion();
-				}
-			}
-		);
-	}
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/DiscoveryV2/HathoraDiscoveryV2GetPingServiceEndpoints.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/DiscoveryV2/HathoraDiscoveryV2GetPingServiceEndpoints.cpp
@@ -27,6 +27,7 @@ void UHathoraDiscoveryV2GetPingServiceEndpoints::Activate()
 		return;
 	}
 
+#pragma warning(disable: 4996)
 	HathoraSDKDiscoveryV2->GetPingServiceEndpoints(
 		UHathoraSDKDiscoveryV2::FHathoraOnGetPingServiceEndpoints::CreateLambda(
 			[this](const TArray<FHathoraDiscoveredPingEndpoint>& Endpoints)
@@ -36,4 +37,5 @@ void UHathoraDiscoveryV2GetPingServiceEndpoints::Activate()
 			}
 		)
 	);
+#pragma warning(default: 4996)
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/HathoraGetPingsForRegions.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/HathoraGetPingsForRegions.cpp
@@ -1,0 +1,41 @@
+// Copyright 2023 Hathora, Inc.
+
+#include "LatentActions/HathoraGetPingsForRegions.h"
+#include "HathoraSDK.h"
+#include "HathoraSDKModule.h"
+
+UHathoraGetPingsForRegions *UHathoraGetPingsForRegions::GetPingsForRegions(
+	UObject *WorldContextObject,
+	TMap<FString, FString> RegionUrls,
+	EHathoraPingType PingType,
+	int32 NumPingsPerRegion
+) {
+	UHathoraGetPingsForRegions *Action = NewObject<UHathoraGetPingsForRegions>();
+	Action->RegionUrls = RegionUrls;
+	Action->PingType = PingType;
+	Action->NumPingsPerRegion = NumPingsPerRegion;
+	Action->RegisterWithGameInstance(WorldContextObject);
+	return Action;
+}
+
+void UHathoraGetPingsForRegions::Activate()
+{
+	if (!IsValid(this))
+	{
+		UE_LOG(LogHathoraSDK, Error, TEXT("GetPingsForRegions failed because the underlying Hathora API is not valid."));
+		return;
+	}
+
+	UHathoraSDK::GetPingsForRegions(
+		RegionUrls,
+		PingType,
+		FHathoraOnGetRegionalPings::CreateLambda(
+			[this](const FHathoraRegionPings& Result)
+			{
+				OnComplete.Broadcast(Result);
+				SetReadyToDestroy();
+			}
+		),
+		NumPingsPerRegion
+	);
+}

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/HathoraGetRegionalPings.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/HathoraGetRegionalPings.cpp
@@ -22,6 +22,7 @@ void UHathoraGetRegionalPings::Activate()
 		return;
 	}
 
+#pragma warning(disable: 4996)
 	UHathoraSDK::GetRegionalPings(
 		FHathoraOnGetRegionalPings::CreateLambda(
 			[this](const FHathoraRegionPings& Result)
@@ -32,4 +33,5 @@ void UHathoraGetRegionalPings::Activate()
 		),
 		NumPingsPerRegion
 	);
+#pragma warning(default: 4996)
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraPingUtility.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraPingUtility.h
@@ -1,0 +1,29 @@
+// Copyright 2023 Hathora, Inc.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HathoraTypes.h"
+#include "HathoraPingUtility.generated.h"
+
+UCLASS()
+class HATHORASDK_API UHathoraPingUtility : public UObject
+{
+	GENERATED_BODY()
+
+public:
+
+	void GetPingsForRegions(TMap<FString, FString> InRegionUrls, EHathoraPingType InPingType, const FHathoraOnGetRegionalPings& OnComplete, int32 InNumPingsPerRegion = 3);
+
+private:
+	TMap<FString, FString> RegionUrls;
+	EHathoraPingType PingType;
+
+	FHathoraOnGetRegionalPings OnGetRegionalPingsComplete;
+	TArray<FHathoraDiscoveredPingEndpoint> PingEndpoints;
+	int32 NumPingsPerRegion;
+	int32 NumPingsPerRegionCompleted;
+	TSharedPtr<TMap<FString, TArray<int32>>> PingResults;
+
+	void PingEachRegion();
+};

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
@@ -25,7 +25,24 @@ public:
 	// Pings are returned in milliseconds.
 	// @param OnComplete The delegate to call when the request is complete with averaged ping times.
 	// @param NumPingsPerRegion The number of pings to send to each region.
+	UE_DEPRECATED(4.0, "Use GetPingsForRegions instead.")
 	static void GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion = 3);
+
+	// Get ping times to the specified regions.
+	// Each region is pinged NumPingsPerRegion times and the
+	// minimum is returned.
+	// Pings are returned in milliseconds.
+	// @param RegionUrls A map of region names to region URL to ping (include `:port` in the URL string if using EHathoraPingType::UDPEcho).
+	// @param PingType The type of ping/protocol to use.
+	// @param OnComplete The delegate to call when the request is complete with averaged ping times.
+	// @param NumPingsPerRegion The number of pings to send to each region.
+	static void GetPingsForRegions(TMap<FString, FString> RegionUrls, EHathoraPingType PingType, const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion = 3);
+
+	// NOTE: This function may uses hardcoded values for the region URLs and may
+	// be outdated. It is recommended that your backend provides the region URLs
+	// to use in GetPingsForRegions instead.
+	UFUNCTION(BlueprintPure)
+	static TMap<FString, FString> GetRegionMap();
 
 	// Create an instance of the Hathora SDK using the AppId, and DevToken if specified,
 	// from Game.ini. See Project Settings > Plugins > HathoraSDK for more information.

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKDiscoveryV2.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKDiscoveryV2.h
@@ -19,6 +19,7 @@ public:
 	// Pings are returned in milliseconds.
 	// @param OnComplete The delegate to call when the request is complete with averaged ping times.
 	// @param NumPingsPerRegion The number of pings to send to each region.
+	UE_DEPRECATED(4.0, "Use UHathoraSDK::GetPingsForRegions instead.")
 	void GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion = 3);
 
 	typedef TDelegate<void(const TArray<FHathoraDiscoveredPingEndpoint>&)> FHathoraOnGetPingServiceEndpoints;
@@ -26,14 +27,8 @@ public:
 	// Returns an array of all regions with a host that a client can ping via ICMP.
 	// See the "Get Regional Pings" functions that will handle the full ping process for you.
 	// @param OnComplete The delegate to call when the request is complete.
+	UE_DEPRECATED(4.0, "Manually specify the regions you'd like to ping in UHathoraSDK::GetPingsForRegions (recommended) or call UHathoraSDK::GetRegionMap to get the URLs for all regions (for this version of the plugin).")
 	void GetPingServiceEndpoints(const FHathoraOnGetPingServiceEndpoints& OnComplete);
 
 private:
-	FHathoraOnGetRegionalPings OnGetRegionalPingsComplete;
-	TArray<FHathoraDiscoveredPingEndpoint> PingEndpoints;
-	int32 NumPingsPerRegion;
-	int32 NumPingsPerRegionCompleted;
-	TSharedPtr<TMap<FString, TArray<int32>>> PingResults;
-
-	void PingEachRegion();
 };

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
@@ -110,8 +110,26 @@ struct FHathoraServerEnvironment
 	FString ProcessId;
 
 	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString DeploymentId;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString BuildTag;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
 	EHathoraCloudRegion Region = EHathoraCloudRegion::Unknown;
 
 	UPROPERTY(BlueprintReadOnly, Category = "Default")
 	int32 RoomsPerProcess = 0;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString InitialRoomId;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString InitialRoomConfig;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	FString Hostname;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Default")
+	int32 DefaultPort = 0;
 };

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
@@ -72,6 +72,8 @@ enum class EHathoraCloudRegion : uint8
 	Tokyo,
 	Sydney,
 	Sao_Paulo,
+	Dubai,
+	Johannesburg,
 	Unknown UMETA(Hidden)
 };
 

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraTypes.h
@@ -135,3 +135,11 @@ struct FHathoraServerEnvironment
 	UPROPERTY(BlueprintReadOnly, Category = "Default")
 	int32 DefaultPort = 0;
 };
+
+UENUM(BlueprintType)
+enum class EHathoraPingType : uint8
+{
+	ICMP,
+	UDPEcho,
+	Unknown UMETA(Hidden)
+};

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/LatentActions/DiscoveryV2/HathoraDiscoveryV2GetPingServiceEndpoints.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/LatentActions/DiscoveryV2/HathoraDiscoveryV2GetPingServiceEndpoints.h
@@ -29,7 +29,9 @@ public:
 		meta =
 			(BlueprintInternalUseOnly = "true",
 			 Category = "HathoraSDK | DiscoveryV2",
-			 WorldContext = "WorldContextObject")
+			 WorldContext = "WorldContextObject",
+			 DeprecatedFunction,
+			 DeprecationMessage = "Manually specify the regions you'd like to ping in UHathoraSDK::GetPingsForRegions (recommended) or call UHathoraSDK::GetRegionMap to get the URLs for all regions (for this version of the plugin).")
 	)
 	static UHathoraDiscoveryV2GetPingServiceEndpoints *GetPingServiceEndpoints(
 		UHathoraSDKDiscoveryV2 *HathoraSDKDiscoveryV2,

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/LatentActions/HathoraGetPingsForRegions.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/LatentActions/HathoraGetPingsForRegions.h
@@ -5,25 +5,27 @@
 #include "CoreMinimal.h"
 #include "Kismet/BlueprintAsyncActionBase.h"
 #include "HathoraTypes.h"
-#include "HathoraGetRegionalPings.generated.h"
+#include "HathoraGetPingsForRegions.generated.h"
 
 UDELEGATE()
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
-	FHathoraGetRegionalPingsComplete, FHathoraRegionPings, Result
+	FHathoraGetPingsForRegionsComplete, FHathoraRegionPings, Result
 );
 
 UCLASS()
-class HATHORASDK_API UHathoraGetRegionalPings : public UBlueprintAsyncActionBase
+class HATHORASDK_API UHathoraGetPingsForRegions : public UBlueprintAsyncActionBase
 {
 	GENERATED_BODY()
 
 public:
 	virtual void Activate() override;
 
-	// Get ping times to all available Hathora Cloud regions.
+	// Get ping times to the specified regions.
 	// Each region is pinged NumPingsPerRegion times and the
 	// minimum is returned.
 	// Pings are returned in milliseconds.
+	// @param RegionUrls A map of region names to region URL to ping (include `:port` in the URL string if using EHathoraPingType::UDPEcho).
+	// @param PingType The type of ping/protocol to use.
 	// @param OnComplete The delegate to call when the request is complete with averaged ping times.
 	// @param NumPingsPerRegion The number of pings to send to each region.
 	UFUNCTION(
@@ -31,17 +33,19 @@ public:
 		meta =
 			(BlueprintInternalUseOnly = "true",
 			 Category = "HathoraSDK",
-			 WorldContext = "WorldContextObject",
-			 DeprecatedFunction,
-			 DeprecationMessage = "Use GetPingsForRegions instead.")
+			 WorldContext = "WorldContextObject")
 	)
-	static UHathoraGetRegionalPings *GetRegionalPings(
+	static UHathoraGetPingsForRegions *GetPingsForRegions(
 		UObject *WorldContextObject,
+		TMap<FString, FString> RegionUrls,
+		EHathoraPingType PingType,
 		int32 NumPingsPerRegion = 3
 	);
 
 	UPROPERTY(BlueprintAssignable)
-	FHathoraGetRegionalPingsComplete OnComplete;
+	FHathoraGetPingsForRegionsComplete OnComplete;
 
+	TMap<FString, FString> RegionUrls;
+	EHathoraPingType PingType;
 	int32 NumPingsPerRegion;
 };

--- a/SDKDemo/Source/SDKDemo.Target.cs
+++ b/SDKDemo/Source/SDKDemo.Target.cs
@@ -8,7 +8,7 @@ public class SDKDemoTarget : TargetRules
 	public SDKDemoTarget( TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Game;
-		DefaultBuildSettings = BuildSettingsVersion.V2;
+		DefaultBuildSettings = BuildSettingsVersion.Latest;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.Add("SDKDemo");
 	}

--- a/SDKDemo/Source/SDKDemo/DemoMenuWidget.cpp
+++ b/SDKDemo/Source/SDKDemo/DemoMenuWidget.cpp
@@ -90,7 +90,9 @@ bool UDemoMenuWidget::Initialize()
 void UDemoMenuWidget::InitiatePing()
 {
 	RegionList->ClearChildren();
-	UHathoraSDK::GetRegionalPings(
+	UHathoraSDK::GetPingsForRegions(
+		UHathoraSDK::GetRegionMap(),
+		EHathoraPingType::ICMP,
 		FHathoraOnGetRegionalPings::CreateLambda(
 			[this](const FHathoraRegionPings& Result)
 			{

--- a/SDKDemo/Source/SDKDemo/LobbyExample/DemoLobbyWidget.cpp
+++ b/SDKDemo/Source/SDKDemo/LobbyExample/DemoLobbyWidget.cpp
@@ -170,7 +170,14 @@ void UDemoLobbyWidget::OnLobbyReady(
 
 void UDemoLobbyWidget::StartPings()
 {
-	UHathoraSDK::GetRegionalPings(
+	// This is supposed to trigger a compiler warning
+	// Your backend/matchmaker should be providing this TMap
+	// instead of calling this fixed, _possibly outdated_ function
+	TMap<FString, FString> RegionMap = UHathoraSDK::GetRegionMap();
+
+	UHathoraSDK::GetPingsForRegions(
+		RegionMap,
+		EHathoraPingType::ICMP,
 		FHathoraOnGetRegionalPings::CreateLambda(
 			[this](const FHathoraRegionPings& Result)
 			{

--- a/SDKDemo/Source/SDKDemoClient.Target.cs
+++ b/SDKDemo/Source/SDKDemoClient.Target.cs
@@ -8,7 +8,7 @@ public class SDKDemoClientTarget : TargetRules
 	public SDKDemoClientTarget( TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Client;
-		DefaultBuildSettings = BuildSettingsVersion.V2;
+		DefaultBuildSettings = BuildSettingsVersion.Latest;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.Add("SDKDemo");
 	}

--- a/SDKDemo/Source/SDKDemoEditor.Target.cs
+++ b/SDKDemo/Source/SDKDemoEditor.Target.cs
@@ -8,7 +8,7 @@ public class SDKDemoEditorTarget : TargetRules
 	public SDKDemoEditorTarget( TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V2;
+		DefaultBuildSettings = BuildSettingsVersion.Latest;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.Add("SDKDemo");
 	}

--- a/SDKDemo/Source/SDKDemoServer.Target.cs
+++ b/SDKDemo/Source/SDKDemoServer.Target.cs
@@ -8,7 +8,7 @@ public class SDKDemoServerTarget : TargetRules
 	public SDKDemoServerTarget( TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Server;
-		DefaultBuildSettings = BuildSettingsVersion.V2;
+		DefaultBuildSettings = BuildSettingsVersion.Latest;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.Add("SDKDemo");
 	}


### PR DESCRIPTION
This PR primarily is to provide a new `HathoraSDK::GetPingsForRegions` method which doesn't call the Discovery API, but rather has an argument of the region names/urls to ping. This method also enables optional UDP echo pinging instead of ICPM (default) with another argument. `HathoraSDK::GetRegionalPings` has been deprecated with appropriate deprecation messages for both C++ and Blueprints. The readme has been updated accordingly and the lobby example (both the C++ and BP versions) now use the updated version (using the new `HathoraSDK::GetRegionMap` method that provides a hardcoded version of all Hathora URLs).

Here are the changes to the `W_LobbyMenu.uasset`:

![image](https://github.com/user-attachments/assets/dc737671-4a02-449c-9c77-c472f59355cc)

^ This used to simply call `GetRegionalPings`

![image](https://github.com/user-attachments/assets/08430da0-4513-4a7a-b79e-e2764b57cf48)

^ This looped on `EHathoraCloudRegion` enum to fill things out instead of using the same `GetRegionMap` function.

This PR also does some other housekeeping:
- Added Dubai and Johannesburg regions
- Update the `DefaultBuildSettings` to use `Latest` in the sample project Targets to better support future engine versions
- Deprecated Discovery API endpoints
- Some minimal updates to outdated readme docs
- Update `UHathoraSDK::GetServerEnvironment()` to include new injected environment variables