### PR TITLE
Fix clang compiler warnings & errors

### DIFF
--- a/SDKDemo/Plugins/HathoraSDK/HathoraSDK.uplugin
+++ b/SDKDemo/Plugins/HathoraSDK/HathoraSDK.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 3,
-	"VersionName": "1.0",
+	"Version": 4,
+	"VersionName": "1.1",
 	"FriendlyName": "HathoraSDK",
 	"Description": "",
 	"Category": "Other",

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraLobbyComponent.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraLobbyComponent.cpp
@@ -4,6 +4,9 @@
 #include "HathoraSDKModule.h"
 #include "HathoraSDK.h"
 #include "HathoraSDKAuthV1.h"
+#include "Engine/Engine.h"
+#include "Engine/TimerHandle.h"
+#include "TimerManager.h"
 
 void UHathoraLobbyComponent::BeginPlay()
 {

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -16,6 +16,11 @@
 
 void UHathoraSDK::GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion)
 {
+	Internal_GetRegionalPings(OnComplete, NumPingsPerRegion);
+}
+
+void UHathoraSDK::Internal_GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion)
+{
 	UHathoraSDK::GetPingsForRegions(
 		UHathoraSDK::GetRegionMap(),
 		EHathoraPingType::ICMP,

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -13,6 +13,8 @@
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
 #include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
 
 void UHathoraSDK::GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion)
 {

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKDiscoveryV2.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKDiscoveryV2.cpp
@@ -6,6 +6,11 @@
 
 void UHathoraSDKDiscoveryV2::GetPingServiceEndpoints(const FHathoraOnGetPingServiceEndpoints& OnComplete)
 {
+	Internal_GetPingServiceEndpoints(OnComplete);
+}
+
+void UHathoraSDKDiscoveryV2::Internal_GetPingServiceEndpoints(const FHathoraOnGetPingServiceEndpoints& OnComplete)
+{
 	TArray<FHathoraDiscoveredPingEndpoint> PingEndpointsResult;
 	TMap<FString, FString> RegionUrls = UHathoraSDK::GetRegionMap();
 

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKLobbyV3.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDKLobbyV3.cpp
@@ -3,6 +3,8 @@
 #include "HathoraSDKLobbyV3.h"
 #include "HathoraSDKModule.h"
 #include "HathoraSDK.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
 
 FString UHathoraSDKLobbyV3::GetVisibilityString(EHathoraLobbyVisibility Visibility)
 {

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/DiscoveryV2/HathoraDiscoveryV2GetPingServiceEndpoints.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/DiscoveryV2/HathoraDiscoveryV2GetPingServiceEndpoints.cpp
@@ -27,8 +27,7 @@ void UHathoraDiscoveryV2GetPingServiceEndpoints::Activate()
 		return;
 	}
 
-#pragma warning(disable: 4996)
-	HathoraSDKDiscoveryV2->GetPingServiceEndpoints(
+	HathoraSDKDiscoveryV2->Internal_GetPingServiceEndpoints(
 		UHathoraSDKDiscoveryV2::FHathoraOnGetPingServiceEndpoints::CreateLambda(
 			[this](const TArray<FHathoraDiscoveredPingEndpoint>& Endpoints)
 			{
@@ -37,5 +36,4 @@ void UHathoraDiscoveryV2GetPingServiceEndpoints::Activate()
 			}
 		)
 	);
-#pragma warning(default: 4996)
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/HathoraGetRegionalPings.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/LatentActions/HathoraGetRegionalPings.cpp
@@ -22,8 +22,7 @@ void UHathoraGetRegionalPings::Activate()
 		return;
 	}
 
-#pragma warning(disable: 4996)
-	UHathoraSDK::GetRegionalPings(
+	UHathoraSDK::Internal_GetRegionalPings(
 		FHathoraOnGetRegionalPings::CreateLambda(
 			[this](const FHathoraRegionPings& Result)
 			{
@@ -33,5 +32,4 @@ void UHathoraGetRegionalPings::Activate()
 		),
 		NumPingsPerRegion
 	);
-#pragma warning(default: 4996)
 }

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
@@ -42,7 +42,7 @@ public:
 	// NOTE: This function may uses hardcoded values for the region URLs and may
 	// be outdated. It is recommended that your backend provides the region URLs
 	// to use in GetPingsForRegions instead.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "HathoraSDK")
 	static TMap<FString, FString> GetRegionMap();
 
 	// Create an instance of the Hathora SDK using the AppId, and DevToken if specified,

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
@@ -89,6 +89,10 @@ public:
 	UPROPERTY(BlueprintReadOnly, Category="HathoraSDK")
 	UHathoraSDKRoomV2* RoomV2;
 
+	friend class UHathoraGetRegionalPings;
+
 private:
 	void SetCredentials(FString AppId, FHathoraSDKSecurity Security);
+
+	static void Internal_GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion = 3);
 };

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKDiscoveryV2.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDKDiscoveryV2.h
@@ -30,5 +30,9 @@ public:
 	UE_DEPRECATED(4.0, "Manually specify the regions you'd like to ping in UHathoraSDK::GetPingsForRegions (recommended) or call UHathoraSDK::GetRegionMap to get the URLs for all regions (for this version of the plugin).")
 	void GetPingServiceEndpoints(const FHathoraOnGetPingServiceEndpoints& OnComplete);
 
+	friend class UHathoraDiscoveryV2GetPingServiceEndpoints;
+
 private:
+	void Internal_GetRegionalPings(const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion = 3);
+	void Internal_GetPingServiceEndpoints(const FHathoraOnGetPingServiceEndpoints& OnComplete);
 };


### PR DESCRIPTION
This PR aims to fix compiler warnings/errors discovered when compiling with clang. Primarily:
- There were missing includes that clang is more strict about
- The `#pragma warning()` macro is only MSVC, so we chose a compiler-agnostic approach with `friend class` to access a non-deprecated private internal function so the Blueprint versions of async functions (which already have deprecation warnings of their own) can call the C++ versions of the deprecated functions without causing a compiler warning (which can be an error for many studios)

CC @joshhills