### PR TITLE
Add recommendation to use UDP pinging and add fallback to ICMP

### DIFF
--- a/SDKDemo/Plugins/HathoraSDK/HathoraSDK.uplugin
+++ b/SDKDemo/Plugins/HathoraSDK/HathoraSDK.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 4,
-	"VersionName": "1.1",
+	"Version": 5,
+	"VersionName": "1.2",
 	"FriendlyName": "HathoraSDK",
 	"Description": "",
 	"Category": "Other",

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraPingUtility.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraPingUtility.cpp
@@ -57,7 +57,12 @@ void UHathoraPingUtility::PingEachRegion()
 		FString Name = RegionUrl.Key;
 		bool bHasPort = RegionUrl.Value.Contains(":");
 		FString Host = bHasPort ? RegionUrl.Value.Left(RegionUrl.Value.Find(":")) : RegionUrl.Value;
-		int32 Port = bHasPort ? FCString::Atoi(*RegionUrl.Value.RightChop(RegionUrl.Value.Find(":") + 1)) : 443;
+
+		if (!bHasPort && PingType == EHathoraPingType::UDPEcho)
+		{
+			UE_LOG(LogHathoraSDK, Warning, TEXT("Region URL %s does not contain a port but EHathoraPingType::UDPEcho was selected; falling back to ICMP PingType."), *RegionUrl.Value);
+			PingType = EHathoraPingType::ICMP;
+		}
 
 		FIcmpEchoResultCallback Callback =
 			[this, Name, Host, CompletedPings, PingsToComplete](FIcmpEchoResult Result)

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Private/HathoraSDK.cpp
@@ -25,7 +25,7 @@ void UHathoraSDK::Internal_GetRegionalPings(const FHathoraOnGetRegionalPings& On
 {
 	UHathoraSDK::GetPingsForRegions(
 		UHathoraSDK::GetRegionMap(),
-		EHathoraPingType::ICMP,
+		EHathoraPingType::UDPEcho,
 		OnComplete,
 		NumPingsPerRegion
 	);

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/HathoraSDK.h
@@ -33,7 +33,7 @@ public:
 	// minimum is returned.
 	// Pings are returned in milliseconds.
 	// @param RegionUrls A map of region names to region URL to ping (include `:port` in the URL string if using EHathoraPingType::UDPEcho).
-	// @param PingType The type of ping/protocol to use.
+	// @param PingType The type of ping/protocol to use. It's recommended to use UDP Echo if possible as some LAN networks block or drop ICMP packets.
 	// @param OnComplete The delegate to call when the request is complete with averaged ping times.
 	// @param NumPingsPerRegion The number of pings to send to each region.
 	static void GetPingsForRegions(TMap<FString, FString> RegionUrls, EHathoraPingType PingType, const FHathoraOnGetRegionalPings& OnComplete, int32 NumPingsPerRegion = 3);

--- a/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/LatentActions/HathoraGetPingsForRegions.h
+++ b/SDKDemo/Plugins/HathoraSDK/Source/HathoraSDK/Public/LatentActions/HathoraGetPingsForRegions.h
@@ -25,7 +25,7 @@ public:
 	// minimum is returned.
 	// Pings are returned in milliseconds.
 	// @param RegionUrls A map of region names to region URL to ping (include `:port` in the URL string if using EHathoraPingType::UDPEcho).
-	// @param PingType The type of ping/protocol to use.
+	// @param PingType The type of ping/protocol to use. It's recommended to use UDP Echo if possible as some LAN networks block or drop ICMP packets.
 	// @param OnComplete The delegate to call when the request is complete with averaged ping times.
 	// @param NumPingsPerRegion The number of pings to send to each region.
 	UFUNCTION(
@@ -38,7 +38,7 @@ public:
 	static UHathoraGetPingsForRegions *GetPingsForRegions(
 		UObject *WorldContextObject,
 		TMap<FString, FString> RegionUrls,
-		EHathoraPingType PingType,
+		EHathoraPingType PingType = EHathoraPingType::UDPEcho,
 		int32 NumPingsPerRegion = 3
 	);
 


### PR DESCRIPTION
Since some LAN networks may drop, or even block, ICMP packets, this PR encourages developers to use the UDP echo servers for pinging with the following changes:
- Set the default value of `PingType` in the Blueprint `GetPingsForRegions` function to `UDPEcho`
- Add code comments for Blueprint and C++ `GetPingsForRegions` functions
- Since changing the default BP value could be a breaking change for some studios who do not have ports in the region URLs, I added a fallback and warning in the ping utility to switch to ICMP if there's no port but UDP was requested